### PR TITLE
Fix: PostGIS identifier length limit

### DIFF
--- a/apps/backend/src/api/routes/ingestion/process.py
+++ b/apps/backend/src/api/routes/ingestion/process.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from airflow_client.client.models.dag_run_patch_body import DAGRunPatchBody
-from data_manipulation.constants import DEFAULT_GEOMETRY_COLUMN
+from data_manipulation.constants import DEFAULT_GEOMETRY_COLUMN, POSTGIS_TABLE_NAME_MAX_LENGTH
 from data_manipulation.database import create_schema, get_available_table_name
 from data_manipulation.models import IntegrityTransformation
 from data_manipulation.utils import (
@@ -117,7 +117,11 @@ def process_staging_data(
     final_table_name = (
         integrity_link.final_table_name
         if integrity_link.last_retrieval_timestamp is not None
-        else get_available_table_name(data_engine, target_schema, sanitize_name(title))
+        else get_available_table_name(
+            data_engine,
+            target_schema,
+            sanitize_name(title, max_length=POSTGIS_TABLE_NAME_MAX_LENGTH),
+        )
     )
     if not final_table_name:
         raise HTTPException(
@@ -127,7 +131,9 @@ def process_staging_data(
 
     # Validate the generated table name (defense in depth)
     try:
-        validate_table_name(final_table_name, context="final")
+        validate_table_name(
+            final_table_name, context="final", max_length=POSTGIS_TABLE_NAME_MAX_LENGTH
+        )
     except ValueError as e:
         logger.error(f"Generated invalid final table name from title '{title}': {e}")
         raise HTTPException(

--- a/libs/data_manipulation/src/data_manipulation/constants.py
+++ b/libs/data_manipulation/src/data_manipulation/constants.py
@@ -2,3 +2,9 @@
 
 DEFAULT_GEOMETRY_COLUMN = "geom"
 DB_URI_PREFIX = "db://"
+
+# PostgreSQL caps identifiers at 63 chars. PostGIS auto-creates a spatial index
+# named `idx_<table>_<geom_col>`, so any table written via to_postgis must leave
+# room for that suffix or the index creation fails mid-write.
+PG_IDENTIFIER_MAX_LENGTH = 63
+POSTGIS_TABLE_NAME_MAX_LENGTH = PG_IDENTIFIER_MAX_LENGTH - len("idx__") - len(DEFAULT_GEOMETRY_COLUMN)

--- a/libs/data_manipulation/src/data_manipulation/constants.py
+++ b/libs/data_manipulation/src/data_manipulation/constants.py
@@ -7,4 +7,6 @@ DB_URI_PREFIX = "db://"
 # named `idx_<table>_<geom_col>`, so any table written via to_postgis must leave
 # room for that suffix or the index creation fails mid-write.
 PG_IDENTIFIER_MAX_LENGTH = 63
-POSTGIS_TABLE_NAME_MAX_LENGTH = PG_IDENTIFIER_MAX_LENGTH - len("idx__") - len(DEFAULT_GEOMETRY_COLUMN)
+POSTGIS_TABLE_NAME_MAX_LENGTH = (
+    PG_IDENTIFIER_MAX_LENGTH - len("idx__") - len(DEFAULT_GEOMETRY_COLUMN)
+)

--- a/libs/data_manipulation/src/data_manipulation/database.py
+++ b/libs/data_manipulation/src/data_manipulation/database.py
@@ -7,6 +7,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.schema import CreateSchema
 
+from data_manipulation.constants import POSTGIS_TABLE_NAME_MAX_LENGTH
 from data_manipulation.logging import configure_logging
 from data_manipulation.validators import validate_schema_name
 
@@ -66,27 +67,39 @@ def table_exists(engine: Engine, schema_name: str, table_name: str) -> bool:
     return inspect(engine).has_table(table_name, schema=schema_name)
 
 
-def get_available_table_name(engine: Engine, schema_name: str, base_table_name: str) -> str | None:
+def get_available_table_name(
+    engine: Engine,
+    schema_name: str,
+    base_table_name: str,
+    max_length: int = POSTGIS_TABLE_NAME_MAX_LENGTH,
+) -> str | None:
     """
     Get an available table name by appending a numeric suffix if needed.
 
     Args:
         engine: SQLAlchemy engine instance
         schema_name: Schema where the table will be created
-        base_table_name: Desired base name for the table)
+        base_table_name: Desired base name for the table
+        max_length: Maximum total length of the returned table name. Defaults
+            to the PostGIS-safe cap so the auto-created spatial index suffix
+            still fits in PostgreSQL's 63-char identifier limit.
     Returns:
         str: Available table name
     """
 
     max_attempts = 20
+    # Reserve space for the largest suffix we might append so every candidate
+    # — base name included — fits within max_length.
+    max_suffix_len = len(f"_{max_attempts - 1}")
+    base_budget = max_length - max_suffix_len
+    base_table_name = base_table_name[:max_length]
 
     for counter in range(max_attempts):
         if counter == 0:
             final_table_name = base_table_name
         else:
             suffix = f"_{counter}"
-            truncate_length = 53 - len(suffix)
-            final_table_name = base_table_name[:truncate_length] + suffix
+            final_table_name = base_table_name[:base_budget] + suffix
         try:
             metadata = MetaData(schema=schema_name)
             Table(final_table_name, metadata, autoload_with=engine)

--- a/libs/data_manipulation/src/data_manipulation/ingestion.py
+++ b/libs/data_manipulation/src/data_manipulation/ingestion.py
@@ -14,7 +14,7 @@ from geoalchemy2 import Geometry
 from sqlalchemy import MetaData, Table, func, select, text
 from sqlalchemy.engine import Engine
 
-from data_manipulation.constants import DEFAULT_GEOMETRY_COLUMN
+from data_manipulation.constants import DEFAULT_GEOMETRY_COLUMN, POSTGIS_TABLE_NAME_MAX_LENGTH
 from data_manipulation.models import ColumnConfig, IntegrityTransformation
 from data_manipulation.transformation.filter_sql import build_sql_column_ops
 from data_manipulation.transformation.transform import apply_transformations
@@ -493,7 +493,7 @@ def write_data_to_postgis(
         create_id: If True, add an 'id_datafeeder' UUID column as primary key
     """
     # Validate identifiers to prevent SQL injection
-    validate_table_name(table_name)
+    validate_table_name(table_name, max_length=POSTGIS_TABLE_NAME_MAX_LENGTH)
     validate_schema_name(schema)
 
     try:

--- a/libs/data_manipulation/src/data_manipulation/utils.py
+++ b/libs/data_manipulation/src/data_manipulation/utils.py
@@ -10,13 +10,14 @@ import requests
 from geopandas import GeoDataFrame
 from pandas import DataFrame
 
+from data_manipulation.constants import PG_IDENTIFIER_MAX_LENGTH
 from data_manipulation.logging import configure_logging
 
 logger = logging.getLogger(__name__)
 configure_logging(logger)
 
 
-def sanitize_name(name: str) -> str:
+def sanitize_name(name: str, max_length: int = PG_IDENTIFIER_MAX_LENGTH) -> str:
     """
     Sanitize a name for use in GeoServer workspace/layer names or database schema names.
 
@@ -29,6 +30,9 @@ def sanitize_name(name: str) -> str:
 
     Args:
         name: The name to sanitize
+        max_length: Truncate the result to this many characters. Defaults to
+            PostgreSQL's 63-char identifier cap; tighten for PostGIS table
+            names (see POSTGIS_TABLE_NAME_MAX_LENGTH).
 
     Returns:
         str: The sanitized name
@@ -65,7 +69,7 @@ def sanitize_name(name: str) -> str:
     if sanitized and sanitized[0].isdigit():
         sanitized = f"layer_{sanitized}"
 
-    return sanitized[:63]
+    return sanitized[:max_length]
 
 
 def resolve_url(url: str) -> str:

--- a/libs/data_manipulation/src/data_manipulation/validators.py
+++ b/libs/data_manipulation/src/data_manipulation/validators.py
@@ -2,29 +2,39 @@
 
 import re
 
-# PostgreSQL identifier rules: max 63 chars, start with lowercase letter,
-# contain only lowercase letters, numbers, underscores
-IDENTIFIER_PATTERN = r"^[a-z][a-z0-9_]{0,62}$"
+from data_manipulation.constants import PG_IDENTIFIER_MAX_LENGTH
+
+# PostgreSQL identifier rules: start with lowercase letter, contain only
+# lowercase letters, numbers, underscores. The length bound is enforced
+# separately so callers can tighten it (e.g. PostGIS table names must leave
+# room for the auto-created spatial index suffix).
+IDENTIFIER_PATTERN = r"^[a-z][a-z0-9_]*$"
 
 
-def validate_postgres_identifier(identifier: str, identifier_type: str = "identifier") -> str:
+def validate_postgres_identifier(
+    identifier: str,
+    identifier_type: str = "identifier",
+    max_length: int = PG_IDENTIFIER_MAX_LENGTH,
+) -> str:
     """
     Validate PostgreSQL identifier (schema, table, column name) to prevent SQL injection.
 
     All PostgreSQL identifiers follow the same rules:
     - Start with a lowercase letter (a-z)
     - Contain only lowercase letters, numbers, and underscores
-    - Maximum 63 characters
+    - Maximum ``max_length`` characters (defaults to PostgreSQL's 63-char cap)
 
     Args:
         identifier: The identifier to validate
         identifier_type: Type of identifier for error messages (e.g., "table name", "schema name")
+        max_length: Maximum allowed length; tighten below 63 when downstream
+            usage requires headroom (e.g. PostGIS spatial index suffix).
 
     Returns:
         The validated identifier
 
     Raises:
-        ValueError: If the identifier contains invalid characters or is empty
+        ValueError: If the identifier contains invalid characters, is empty, or exceeds max_length
     """
     if not identifier or not identifier.strip():
         raise ValueError(f"{identifier_type.capitalize()} cannot be empty")
@@ -33,16 +43,29 @@ def validate_postgres_identifier(identifier: str, identifier_type: str = "identi
         raise ValueError(
             f"Invalid {identifier_type} '{identifier}'. "
             f"{identifier_type.capitalize()}s must start with a lowercase letter and contain only "
-            "lowercase letters, numbers, and underscores (max 63 characters)."
+            "lowercase letters, numbers, and underscores."
         )
+
+    if len(identifier) > max_length:
+        raise ValueError(
+            f"Invalid {identifier_type} '{identifier}': length {len(identifier)} exceeds "
+            f"maximum of {max_length} characters."
+        )
+
     return identifier
 
 
 # Convenience aliases for better readability in code
-def validate_table_name(table_name: str, context: str = "table") -> str:
+def validate_table_name(
+    table_name: str,
+    context: str = "table",
+    max_length: int = PG_IDENTIFIER_MAX_LENGTH,
+) -> str:
     """Validate table name. Convenience wrapper around validate_postgres_identifier."""
     return validate_postgres_identifier(
-        table_name, f"{context} table name" if context != "table" else "table name"
+        table_name,
+        f"{context} table name" if context != "table" else "table name",
+        max_length=max_length,
     )
 
 

--- a/libs/data_manipulation/tests/test_ingestion.py
+++ b/libs/data_manipulation/tests/test_ingestion.py
@@ -12,6 +12,7 @@ from shapely.geometry import Point
 from sqlalchemy.engine import Engine
 
 from data_manipulation import IntegrityTransformation, apply_transformations
+from data_manipulation.constants import POSTGIS_TABLE_NAME_MAX_LENGTH
 from data_manipulation.ingestion import (
     _read_file_encoded,  # pyright: ignore[reportPrivateUsage]
     ingest_data_from_database_into_postgis,
@@ -802,6 +803,29 @@ class TestWriteDataToPostgis:
 
         with pytest.raises(ValueError):
             write_data_to_postgis(gdf, "invalid-table-name!", mock_engine, "public")
+
+    def test_write_rejects_table_name_too_long_for_postgis_index(self, mock_engine: Mock) -> None:
+        """Names that would overflow PostGIS's `idx_<table>_geom` index must be rejected up-front."""
+        gdf = GeoDataFrame({"col1": [1, 2], "geometry": [Point(0, 0), Point(1, 1)]})
+        too_long = "a" * (POSTGIS_TABLE_NAME_MAX_LENGTH + 1)
+
+        with patch.object(gdf, "to_postgis") as mock_to_postgis:
+            with pytest.raises(ValueError, match="exceeds maximum"):
+                write_data_to_postgis(gdf, too_long, mock_engine, "public")
+            mock_to_postgis.assert_not_called()
+
+    def test_write_accepts_table_name_at_postgis_cap(self, mock_engine: Mock) -> None:
+        """A table name at the PostGIS-safe cap must pass validation."""
+        gdf = GeoDataFrame(
+            {"col1": [1, 2]},
+            geometry=gpd.GeoSeries([Point(0, 0), Point(1, 1)], name="geom"),
+        )
+        at_cap = "a" * POSTGIS_TABLE_NAME_MAX_LENGTH
+
+        with patch("data_manipulation.ingestion._get_table_row_count", return_value=2):
+            with patch.object(gdf, "to_postgis") as mock_to_postgis:
+                write_data_to_postgis(gdf, at_cap, mock_engine, "public")
+                mock_to_postgis.assert_called_once()
 
     def test_write_sql_injection_prevented(self, mock_engine: Mock) -> None:
         """Test that SQL injection attempts are prevented."""

--- a/libs/data_manipulation/tests/test_utils.py
+++ b/libs/data_manipulation/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from data_manipulation.constants import POSTGIS_TABLE_NAME_MAX_LENGTH
 from data_manipulation.utils import resolve_url, sanitize_name
 
 
@@ -79,6 +80,16 @@ class TestSanitizeName:
         assert sanitize_name("__Test Layer #1__") == "test_layer_1"
         assert sanitize_name("@@@123DataSet") == "layer_123dataset"
         assert sanitize_name("Layer (v2.0)") == "layer_v20"
+
+    def test_default_truncates_to_63(self):
+        """Default cap matches PostgreSQL's identifier length."""
+        result = sanitize_name("a" * 100)
+        assert len(result) == 63
+
+    def test_custom_max_length_truncates(self):
+        """max_length overrides the default 63-char cap."""
+        result = sanitize_name("a" * 100, max_length=POSTGIS_TABLE_NAME_MAX_LENGTH)
+        assert len(result) == POSTGIS_TABLE_NAME_MAX_LENGTH
 
     def test_empty_after_sanitization(self):
         """Test edge case where sanitization might result in empty string."""

--- a/libs/data_manipulation/tests/test_validators.py
+++ b/libs/data_manipulation/tests/test_validators.py
@@ -4,6 +4,7 @@ import re
 
 import pytest
 
+from data_manipulation.constants import POSTGIS_TABLE_NAME_MAX_LENGTH
 from data_manipulation.validators import (
     IDENTIFIER_PATTERN,
     validate_postgres_identifier,
@@ -187,8 +188,37 @@ class TestIdentifierPattern:
             "a-b",  # Hyphen
             "a.b",  # Dot
             "a b",  # Space
-            "a" * 64,  # Too long
             "",  # Empty
         ]
         for identifier in invalid_identifiers:
             assert not re.match(IDENTIFIER_PATTERN, identifier)
+
+
+class TestMaxLength:
+    """Test the configurable max_length cap."""
+
+    def test_default_allows_63_chars(self):
+        assert validate_postgres_identifier("a" * 63) == "a" * 63
+
+    def test_default_rejects_64_chars(self):
+        with pytest.raises(ValueError, match="exceeds maximum of 63"):
+            validate_postgres_identifier("a" * 64)
+
+    def test_custom_max_length_allows_at_cap(self):
+        assert (
+            validate_table_name("a" * POSTGIS_TABLE_NAME_MAX_LENGTH, max_length=POSTGIS_TABLE_NAME_MAX_LENGTH)
+            == "a" * POSTGIS_TABLE_NAME_MAX_LENGTH
+        )
+
+    def test_custom_max_length_rejects_above_cap(self):
+        too_long = "a" * (POSTGIS_TABLE_NAME_MAX_LENGTH + 1)
+        with pytest.raises(
+            ValueError,
+            match=rf"exceeds maximum of {POSTGIS_TABLE_NAME_MAX_LENGTH}",
+        ):
+            validate_table_name(too_long, max_length=POSTGIS_TABLE_NAME_MAX_LENGTH)
+
+    def test_error_message_reports_actual_length(self):
+        too_long = "a" * 70
+        with pytest.raises(ValueError, match="length 70 exceeds"):
+            validate_postgres_identifier(too_long)

--- a/libs/data_manipulation/tests/test_validators.py
+++ b/libs/data_manipulation/tests/test_validators.py
@@ -206,7 +206,9 @@ class TestMaxLength:
 
     def test_custom_max_length_allows_at_cap(self):
         assert (
-            validate_table_name("a" * POSTGIS_TABLE_NAME_MAX_LENGTH, max_length=POSTGIS_TABLE_NAME_MAX_LENGTH)
+            validate_table_name(
+                "a" * POSTGIS_TABLE_NAME_MAX_LENGTH, max_length=POSTGIS_TABLE_NAME_MAX_LENGTH
+            )
             == "a" * POSTGIS_TABLE_NAME_MAX_LENGTH
         )
 


### PR DESCRIPTION
# Fix: PostGIS table-name length must leave room for auto-created spatial index

## Problem

Writing a GeoDataFrame to PostGIS with a long table name failed with:

> `Error writing data to PostGIS table data.orb003_centroides_within_area_snap_to_network_test_items: Identifier 'idx_orb003_centroides_within_area_snap_to_network_test_items_geom' exceeds maximum length of 63 characters`

PostgreSQL caps identifiers at **63 characters**. Even when `to_postgis(..., index=False)` is set, PostGIS still auto-creates a spatial index named `idx_<table>_<geom_col>`. If the synthesized index name exceeds 63 chars, the write fails mid-operation — after data has been streamed and after the user has already committed to that table name through the UI.

Existing validators (`validate_postgres_identifier`, `validate_table_name`) only enforced the raw 63-char limit on the table name itself, so a 60-char table name passed validation and then blew up at write time.

## Solution

Enforce the **PostGIS-safe** length cap up-front, derived from the geometry column convention:

```
POSTGIS_TABLE_NAME_MAX_LENGTH = 63 − len("idx__") − len(DEFAULT_GEOMETRY_COLUMN) = 54
```

### Non-goals

- GeoServer workspace / layer naming is unchanged — different identifier rules, no PostGIS index involved. `sanitize_name`'s default cap stays at 63.
- The cleanup-path `validate_table_name` (drop-table on rollback) still uses the default 63-char cap so legacy oversized tables remain droppable.

## Manual testing

Reproduce the original bug by ingesting a dataset whose sanitised title exceeds 54 characters:

1. Before this PR: the staging upload succeeds, then the final-write step crashes with the `Identifier '...' exceeds maximum length of 63 characters` error.
2. After this PR: the title is truncated to 54 chars during derivation, the PostGIS write succeeds, and `idx_<table>_geom` fits within the 63-char limit.

If the user bypasses sanitisation (e.g. supplies a pre-validated name via the DB-import flow), the `write_data_to_postgis` validator now rejects it up-front with a clear message identifying the offending length and the cap.
