### PR TITLE
fix(airflow): disable remote S3 logging by default

### DIFF
--- a/docker/compose.airflow.yaml
+++ b/docker/compose.airflow.yaml
@@ -73,10 +73,10 @@ x-airflow-common:
     AIRFLOW_STAGING_TIMEOUT_SECONDS: ${AIRFLOW_STAGING_TIMEOUT_SECONDS:-600}
     AIRFLOW__SECRETS__BACKEND: 'airflow.secrets.local_filesystem.LocalFilesystemBackend'
     AIRFLOW__SECRETS__BACKEND_KWARGS: '{"variables_file_path": "/opt/airflow/files/var.json", "connections_file_path": "/opt/airflow/files/conn.json"}'
-    AIRFLOW__LOGGING__REMOTE_LOGGING: 'true'
-    AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID: 'AWS_S3'
-    AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER: 's3://int-datafeeder'
-    AIRFLOW__LOGGING__DELETE_LOCAL_LOGS: 'true'
+    AIRFLOW__LOGGING__REMOTE_LOGGING: 'false'
+    # AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID: 'AWS_S3'
+    # AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER: 's3://int-datafeeder'
+    # AIRFLOW__LOGGING__DELETE_LOCAL_LOGS: 'true'
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server


### PR DESCRIPTION
Remote logging to s3://int-datafeeder requires an AWS_S3 connection that isn't available in the default local/dev setup, causing Airflow task logs to fail. Disable remote logging and comment out the related settings so logs are written locally.

Error from airflow logs when ingesting a dataset : 
```bash
botocore.exceptions.NoCredentialsError: Unable to locate credentials
```