### PR TITLE
Feat: Attach GeoNetwork record links to created GeoServer layers

### DIFF
--- a/apps/backend/src/api/routes/ingestion/process.py
+++ b/apps/backend/src/api/routes/ingestion/process.py
@@ -11,6 +11,7 @@ from data_manipulation.utils import (
 )
 from data_manipulation.validators import validate_table_name
 from fastapi import APIRouter, Header, HTTPException, Query
+from geoservercloud.models.common import MetadataLink
 from sqlalchemy import MetaData, Table, func, select
 
 from src.api.deps import (
@@ -366,6 +367,23 @@ async def dag_success_callback(
                 if bbox_result:
                     bbox = compute_bbox_from_postgis_stextent_string(bbox_result)
 
+        metadata_links: list[MetadataLink] | None = None
+        if integrity_link.metadata_id:
+            metadata_links = [
+                MetadataLink(
+                    url=settings.GEONETWORK_XML_RECORD_URL.format(
+                        metadata_id=integrity_link.metadata_id
+                    ),
+                    metadata_type="ISO19115:2003",
+                    mime_type="text/xml",
+                ),
+                MetadataLink(
+                    url=settings.CATALOGUE_URL.format(metadata_id=integrity_link.metadata_id),
+                    metadata_type="ISO19115:2003",
+                    mime_type="text/html",
+                ),
+            ]
+
         await geoserver_service.create_layer(
             workspace_name=workspace_name,
             datastore_name=datastore_name,
@@ -375,6 +393,7 @@ async def dag_success_callback(
             epsg=epsg or 4326,
             is_geographic=is_geographic,
             bbox=bbox,
+            metadata_links=metadata_links,
         )
         integrity_link.data_id = workspace_name + ":" + final_table_name
         logger.info(

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -262,6 +262,11 @@ class Settings(BaseSettings):
     def emails_enabled(self) -> bool:
         return bool(self.SMTP_HOST and self.EMAILS_FROM_EMAIL)
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def GEONETWORK_XML_RECORD_URL(self) -> str:
+        return f"{self.GEONETWORK_URL}/srv/api/records/{{metadata_id}}/formatters/xml"
+
     @model_validator(mode="after")
     def _set_default_emails_from(self) -> Self:
         if not self.EMAILS_FROM_NAME:

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -171,7 +171,7 @@ class Settings(BaseSettings):
 
     # Catalogue
     CATALOGUE_URL: str = Field(
-        default="",
+        default="http://localhost:8080/datahub/dataset/{metadata_id}",
         validation_alias=AliasChoices("catalogueUrl", "CATALOGUE_URL"),
     )
 

--- a/apps/backend/src/services/geoserver.py
+++ b/apps/backend/src/services/geoserver.py
@@ -12,6 +12,7 @@ from data_manipulation.geoserver import (
     update_layer_bbox as dm_update_layer_bbox,
 )
 from geoservercloud import GeoServerCloud  # type: ignore[import-untyped]
+from geoservercloud.models.common import MetadataLink
 from pydantic import BaseModel
 
 from src.core.logging import get_logger
@@ -169,6 +170,7 @@ class GeoServerService:
         epsg: int = 4326,
         is_geographic: bool = True,
         bbox: dict[str, float] = {"minx": -1.0, "miny": -1.0, "maxx": 0.0, "maxy": 0.0},
+        metadata_links: list[MetadataLink] | None = None,
     ) -> LayerCreationResult:
         """
         Create a WFS and WMS layer from a database table.
@@ -199,6 +201,7 @@ class GeoServerService:
             epsg=epsg,
             is_geographic=is_geographic,
             bbox=bbox,
+            metadata_links=metadata_links,
         )
 
         # Build service URLs using build_layer_urls

--- a/apps/backend/tests/services/test_geoserver.py
+++ b/apps/backend/tests/services/test_geoserver.py
@@ -122,6 +122,7 @@ class TestGeoServerService:
             epsg=4326,
             is_geographic=True,
             bbox={"minx": -1.0, "miny": -1.0, "maxx": 0.0, "maxy": 0.0},
+            metadata_links=None,
         )
 
         # Verify return value structure
@@ -327,6 +328,7 @@ class TestGeoServerService:
             epsg=4326,
             is_geographic=False,
             bbox={"minx": -1.0, "miny": -1.0, "maxx": 0.0, "maxy": 0.0},
+            metadata_links=None,
         )
 
         # Verify return value structure

--- a/libs/data_manipulation/src/data_manipulation/geoserver.py
+++ b/libs/data_manipulation/src/data_manipulation/geoserver.py
@@ -1,6 +1,7 @@
 """GeoServer layer creation utilities."""
 
 from geoservercloud import GeoServerCloud  # type: ignore[import-untyped]
+from geoservercloud.models.common import MetadataLink
 from geoservercloud.models.datastore import DataStore
 from geoservercloud.models.featuretype import FeatureType
 from geoservercloud.services import RestService
@@ -92,6 +93,7 @@ def create_layer(
     epsg: int = 4326,
     is_geographic: bool = True,
     bbox: dict[str, float] = {"minx": -1.0, "miny": -1.0, "maxx": 0.0, "maxy": 0.0},
+    metadata_links: list[MetadataLink] | None = None,
 ) -> None:
     """
     Create a feature type (layer) in GeoServer from a database table.
@@ -148,6 +150,7 @@ def create_layer(
             epsg_code=epsg,
             native_bounding_box=native_bounding_box,
             lat_lon_bounding_box=lat_lon_bounding_box,
+            metadata_links=metadata_links,
         )
 
         rest_service = RestService(


### PR DESCRIPTION
## What

When publishing a GeoServer feature type at the end of an ingestion, attach two `MetadataLink` entries pointing to the freshly-created GeoNetwork record:

- `text/xml` — ISO 19139 export via the GN API
- `text/html` — DataHub landing page (or whatever GN admin URL template is configured downstream)

## Why

GeoServer clients (OGC catalogs, ETL tools, QGIS) can discover the metadata directly from a layer's capabilities document instead of having to cross-reference the catalog out-of-band.

## Design choices

- **URL templates use `{metadata_id}`** as the placeholder. `CATALOGUE_URL` already carried this convention; `GEONETWORK_XML_RECORD_URL` follows the same.
- **`GEONETWORK_XML_RECORD_URL` is a `@computed_field` derived from `GEONETWORK_URL`**, not a separate env var. Path suffix is fixed (`/srv/api/records/{metadata_id}/formatters/xml`). One less knob to configure.
- **`metadata_type = "ISO19115:2003"`** hard-coded on both links, overriding the geoservercloud default (`TC211`) to match the spec.
- **Links are attached only when `integrity_link.metadata_id` is set**, so we never publish broken links if metadata creation failed upstream.
- **`metadata_links` flows as an optional kwarg through the three layers** (`data_manipulation.create_layer` → `GeoServerService.create_layer` → `dag_success_callback`), keeping each layer single-purpose and backwards-compatible.
