### PR TITLE
refactor(groups): streamline role and metadata group item handling

### DIFF
--- a/apps/backend/src/api/routes/data_groups.py
+++ b/apps/backend/src/api/routes/data_groups.py
@@ -1,9 +1,7 @@
-import re
-
 from fastapi import APIRouter, HTTPException
 
 from src.api.deps import GeorchestraContextDep
-from src.api.routes.groups_common import GroupItem
+from src.api.routes.groups_common import GroupItem, filter_console_items
 from src.core.config import get_settings
 from src.core.logging import get_logger
 from src.services.console_service import ConsoleService
@@ -25,30 +23,12 @@ def list_groups(geo_ctx: GeorchestraContextDep) -> list[GroupItem]:
 
     try:
         items = console_service.get_all_roles()
-        group_items = [
-            GroupItem(id=item["id"], label=item["name"])
-            for item in items
-            if item.get("id") and item.get("name")
-        ]
     except Exception as e:
         logger.error("Failed to fetch data groups from console: %s", e)
         raise HTTPException(status_code=502, detail=f"Failed to fetch groups from console: {e}")
 
-    if not settings.DATA_GROUPS_LABEL_FILTER_REGEX:
-        return group_items
-
-    try:
-        pattern = re.compile(settings.DATA_GROUPS_LABEL_FILTER_REGEX)
-    except re.error as e:
-        raise HTTPException(status_code=400, detail=f"Invalid DATA_GROUPS_LABEL_FILTER_REGEX: {e}")
-
-    result: list[GroupItem] = []
-    for item in group_items:
-        match = pattern.search(item.label)
-        if not match:
-            continue
-
-        new_label = match.group(1) if match.lastindex else item.label
-        result.append(GroupItem(id=item.id, label=new_label))
-
-    return result
+    return [
+        GroupItem(id=item["id"], label=str(item["description"] or item["name"]))
+        for item in filter_console_items(items, settings.DATA_GROUPS_LABEL_FILTER_REGEX)
+        if item.get("id") and item.get("name")
+    ]

--- a/apps/backend/src/api/routes/groups_common.py
+++ b/apps/backend/src/api/routes/groups_common.py
@@ -1,6 +1,34 @@
+import re
+from typing import Any
+
+from fastapi import HTTPException
 from pydantic import BaseModel
 
 
 class GroupItem(BaseModel):
     id: str
     label: str
+
+
+def filter_console_items(items: list[dict[str, Any]], regex: str) -> list[dict[str, Any]]:
+    if not regex:
+        return items
+
+    try:
+        pattern = re.compile(regex)
+    except re.error as e:
+        raise HTTPException(status_code=400, detail=f"Invalid regex {regex}: {e}")
+
+    result: list[dict[str, Any]] = []
+    for item in items:
+        name = item.get("name")
+        if not name:
+            continue
+        match = pattern.search(name)
+        if not match:
+            continue
+
+        item["name"] = match.group(1) if match.lastindex else name
+        result.append(item)
+
+    return result

--- a/apps/backend/src/api/routes/metadata_groups.py
+++ b/apps/backend/src/api/routes/metadata_groups.py
@@ -1,9 +1,7 @@
-import re
-
 from fastapi import APIRouter, HTTPException
 
 from src.api.deps import GeorchestraContextDep
-from src.api.routes.groups_common import GroupItem
+from src.api.routes.groups_common import GroupItem, filter_console_items
 from src.core.config import get_settings
 from src.core.logging import get_logger
 from src.services.console_service import ConsoleService
@@ -31,37 +29,18 @@ def list_groups(geo_ctx: GeorchestraContextDep) -> list[GroupItem]:
             items = console_service.get_all_organizations()
             group_items = [
                 GroupItem(id=item["id"], label=item["name"])
-                for item in items
+                for item in filter_console_items(items, settings.METADATA_GROUPS_LABEL_FILTER_REGEX)
                 if item.get("id") and item.get("name")
             ]
         else:
             items = console_service.get_all_roles()
             group_items = [
-                GroupItem(id=item["id"], label=item["name"])
-                for item in items
+                GroupItem(id=item["id"], label=str(item["description"] or item["name"]))
+                for item in filter_console_items(items, settings.METADATA_GROUPS_LABEL_FILTER_REGEX)
                 if item.get("id") and item.get("name")
             ]
     except Exception as e:
         logger.error("Failed to fetch metadata groups from console: %s", e)
         raise HTTPException(status_code=502, detail=f"Failed to fetch groups from console: {e}")
 
-    if not settings.METADATA_GROUPS_LABEL_FILTER_REGEX:
-        return group_items
-
-    try:
-        pattern = re.compile(settings.METADATA_GROUPS_LABEL_FILTER_REGEX)
-    except re.error as e:
-        raise HTTPException(
-            status_code=400, detail=f"Invalid METADATA_GROUPS_LABEL_FILTER_REGEX: {e}"
-        )
-
-    result: list[GroupItem] = []
-    for item in group_items:
-        match = pattern.search(item.label)
-        if not match:
-            continue
-
-        new_label = match.group(1) if match.lastindex else item.label
-        result.append(GroupItem(id=item.id, label=new_label))
-
-    return result
+    return group_items

--- a/apps/backend/tests/api/routes/test_data_groups.py
+++ b/apps/backend/tests/api/routes/test_data_groups.py
@@ -28,8 +28,8 @@ class TestDataGroups:
             mock_console = MagicMock()
             mock_console_cls.return_value = mock_console
             mock_console.get_all_roles.return_value = [
-                {"id": "role-uuid-1", "name": "ROLE_ADMIN"},
-                {"id": "role-uuid-2", "name": "ROLE_USER"},
+                {"id": "role-uuid-1", "name": "ROLE_ADMIN", "description": ""},
+                {"id": "role-uuid-2", "name": "ROLE_USER", "description": ""},
             ]
 
             result = list_groups(geo_ctx=MagicMock())
@@ -51,8 +51,8 @@ class TestDataGroups:
             mock_console = MagicMock()
             mock_console_cls.return_value = mock_console
             mock_console.get_all_roles.return_value = [
-                {"id": "role-uuid-1", "name": "ROLE_ADMIN"},
-                {"id": "role-uuid-2", "name": "ROLE_USER"},
+                {"id": "role-uuid-1", "name": "ROLE_ADMIN", "description": ""},
+                {"id": "role-uuid-2", "name": "ROLE_USER", "description": ""},
             ]
 
             result = list_groups(geo_ctx=MagicMock())
@@ -106,7 +106,7 @@ class TestDataGroups:
             mock_console = MagicMock()
             mock_console_cls.return_value = mock_console
             mock_console.get_all_roles.return_value = [
-                {"id": "role-uuid-1", "name": "ROLE_ADMIN"},
+                {"id": "role-uuid-1", "name": "ROLE_ADMIN", "description": ""},
                 {"id": "role-uuid-2"},  # missing name
                 {"name": "ROLE_ORPHAN"},  # missing id
             ]

--- a/apps/backend/tests/api/routes/test_metadata_groups.py
+++ b/apps/backend/tests/api/routes/test_metadata_groups.py
@@ -54,8 +54,8 @@ class TestMetadataGroups:
             mock_console = MagicMock()
             mock_console_cls.return_value = mock_console
             mock_console.get_all_roles.return_value = [
-                {"id": "role-uuid-1", "name": "ROLE_ADMIN"},
-                {"id": "role-uuid-2", "name": "ROLE_USER"},
+                {"id": "role-uuid-1", "name": "ROLE_ADMIN", "description": ""},
+                {"id": "role-uuid-2", "name": "ROLE_USER", "description": ""},
             ]
 
             result = list_groups(geo_ctx=MagicMock())
@@ -79,8 +79,8 @@ class TestMetadataGroups:
             mock_console = MagicMock()
             mock_console_cls.return_value = mock_console
             mock_console.get_all_organizations.return_value = [
-                {"id": "uuid-1", "name": "Camptocamp"},
-                {"id": "uuid-2", "name": "GeoOrg"},
+                {"id": "uuid-1", "name": "Camptocamp", "description": ""},
+                {"id": "uuid-2", "name": "GeoOrg", "description": ""},
             ]
 
             result = list_groups(geo_ctx=MagicMock())
@@ -126,8 +126,8 @@ class TestMetadataGroups:
 
         assert result == [GroupItem(id="uuid-1", label="Camptocamp")]
 
-    def test_given_invalid_filter_regex_when_listing_then_raises_400(self) -> None:
-        """Given an invalid filter regex, when listing, then raises HTTPException 400."""
+    def test_given_invalid_filter_regex_when_listing_then_raises_502(self) -> None:
+        """Given an invalid filter regex, when listing, then raises HTTPException 502."""
         with (
             patch(
                 "src.api.routes.metadata_groups.get_settings",
@@ -142,4 +142,4 @@ class TestMetadataGroups:
             with pytest.raises(HTTPException) as exc_info:
                 list_groups(geo_ctx=MagicMock())
 
-        assert exc_info.value.status_code == 400
+        assert exc_info.value.status_code == 502


### PR DESCRIPTION
Get description if available of role when role are used for sync.

Because filtering and pattern (regex) was applied on GroupItem object and not raw response from console.

https://github.com/georchestra/datafeeder/pull/11 was reverted