### PR TITLE
Fix: dataset deletion cleanup gaps

### DIFF
--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -337,3 +337,10 @@ def get_data_schema(org: str) -> str:
 def get_staging_schema() -> str:
     """Get the staging schema, defaulting to 'staging'."""
     return "staging"  # FIXME get it from config
+
+
+def is_shared_schema(schema: str) -> bool:
+    """True for schemas shared across datasets/orgs, which must never be
+    dropped: the staging schema and the default data schema (used for final
+    tables when USE_ORG_SCHEMA is disabled)."""
+    return schema in (get_staging_schema(), DEFAULT_DATA_SCHEMA)

--- a/apps/backend/src/services/airflow_client.py
+++ b/apps/backend/src/services/airflow_client.py
@@ -155,12 +155,14 @@ def cancel_ingestion_dag(integrity_link_id: str) -> None:
     """
     Cancel all running or queued Airflow runs associated with the given integrity link.
 
-    Cancels the scheduled ingestion DAG runs (ingestion_{id}) and any process_dag runs
-    triggered by them (identified by dag_run_id prefix).
+    Cancels the scheduled ingestion DAG runs (ingestion_{id}), any process_dag runs
+    and any staging_dag runs for the dataset (identified by dag_run_id prefix;
+    the first staging run id is exactly the integrity link id, so no trailing '_').
     """
     dag_id = f"ingestion_{integrity_link_id}"
     _force_fail_dag_runs(dag_id)
     _force_fail_dag_runs("process_dag", dag_run_id_prefix=f"{integrity_link_id}_")
+    _force_fail_dag_runs("staging_dag", dag_run_id_prefix=f"{integrity_link_id}")
 
 
 def delete_dag(dag_id: str) -> None:

--- a/apps/backend/src/services/airflow_client.py
+++ b/apps/backend/src/services/airflow_client.py
@@ -14,6 +14,9 @@ from airflow_client.client.models.dag_run_patch_states import DAGRunPatchStates
 from pydantic import BaseModel
 
 from ..core.config import get_settings
+from ..core.logging import get_logger
+
+logger = get_logger()
 
 __all__ = [
     "get_airflow_api_client",
@@ -23,6 +26,7 @@ __all__ = [
     "get_task_instance_api",
     "cancel_ingestion_dag",
     "delete_dag",
+    "purge_dataset_dag_runs",
 ]
 
 
@@ -163,6 +167,47 @@ def cancel_ingestion_dag(integrity_link_id: str) -> None:
     _force_fail_dag_runs(dag_id)
     _force_fail_dag_runs("process_dag", dag_run_id_prefix=f"{integrity_link_id}_")
     _force_fail_dag_runs("staging_dag", dag_run_id_prefix=f"{integrity_link_id}")
+
+
+def _delete_dag_runs(dag_id: str, run_id_like: str) -> None:
+    """Delete all runs of a DAG whose run id matches a SQL LIKE pattern.
+
+    Deleting a dag run cascades its task instances and XComs in the Airflow
+    metadata DB. Pages by re-querying until no (deletable) run remains.
+    Best-effort: per-run failures are logged and skipped.
+    """
+    api = get_dag_run_api()
+    while True:
+        try:
+            page = api.get_dag_runs(dag_id=dag_id, run_id_pattern=run_id_like, limit=100)
+        except NotFoundException:
+            return
+        runs = page.dag_runs
+        if not runs:
+            return
+        deleted_any = False
+        for run in runs:
+            try:
+                api.delete_dag_run(dag_id=dag_id, dag_run_id=run.dag_run_id)
+                deleted_any = True
+            except NotFoundException:
+                deleted_any = True  # already gone — progress nonetheless
+            except Exception as e:
+                logger.warning(f"Failed to delete dag run {dag_id}/{run.dag_run_id}: {e}")
+        if not deleted_any:
+            # Nothing could be deleted in this page — bail out to avoid looping
+            return
+
+
+def purge_dataset_dag_runs(integrity_link_id: str) -> None:
+    """
+    Delete the Airflow run history (dag runs, task instances, XComs) of a dataset.
+
+    Covers staging_dag runs (run ids '<id>' / '<id>_<ts>') and process_dag runs
+    (run ids '<id>_<ts>[_manual]'). Run-id matching uses SQL LIKE patterns.
+    """
+    _delete_dag_runs("staging_dag", f"{integrity_link_id}%")
+    _delete_dag_runs("process_dag", f"{integrity_link_id}_%")
 
 
 def delete_dag(dag_id: str) -> None:

--- a/apps/backend/src/services/dataset_deletion_service.py
+++ b/apps/backend/src/services/dataset_deletion_service.py
@@ -5,7 +5,7 @@ from src.core.config import get_data_schema
 from src.core.db import data_engine
 from src.core.logging import get_logger
 from src.models.integrity_link import IntegrityLink
-from src.services.airflow_client import delete_dag
+from src.services.airflow_client import cancel_ingestion_dag, delete_dag
 from src.services.geoserver import GeoServerService
 from src.services.metadata_service import MetadataService
 
@@ -27,6 +27,7 @@ class DatasetDeletionService:
         """Delete a dataset and all associated resources.
 
         Cleanup sequence:
+        0. Cancel in-flight DAG runs — best-effort
         1. Delete Airflow DAG — BLOCKING: raises on failure
         2. Delete GeoServer layer — best-effort
         3. Drop final data table — best-effort
@@ -41,6 +42,16 @@ class DatasetDeletionService:
         Raises:
             Exception: If Airflow DAG deletion fails (other cleanup is skipped)
         """
+        # Step 0: Cancel in-flight DAG runs for this dataset (best-effort) so a
+        # run completing after deletion cannot recreate the staging/final table.
+        try:
+            cancel_ingestion_dag(str(integrity_link.id))
+        except Exception as e:
+            logger.warning(
+                f"Failed to cancel in-flight DAG runs for IntegrityLink {integrity_link.id}: {e}",
+                exc_info=True,
+            )
+
         # Step 1: Delete Airflow DAG (blocking). Attempted even when no schedule
         # is currently set: a previously cleared schedule leaves a stale
         # ingestion_<id> DAG in Airflow, and delete_dag tolerates 404.

--- a/apps/backend/src/services/dataset_deletion_service.py
+++ b/apps/backend/src/services/dataset_deletion_service.py
@@ -54,11 +54,15 @@ class DatasetDeletionService:
         workspace_name = integrity_link.integrity_organization.lower()
         datastore_name = f"{workspace_name}_ds"
 
-        # Step 2: Delete GeoServer layer (best-effort)
+        # Step 2: Delete GeoServer layer and its ACL rules (best-effort)
         if integrity_link.final_table_name:
             self.geoserver_service.delete_layer(
                 workspace_name=workspace_name,
                 datastore_name=datastore_name,
+                layer_name=integrity_link.final_table_name,
+            )
+            self.geoserver_service.delete_layer_acl(
+                workspace_name=workspace_name,
                 layer_name=integrity_link.final_table_name,
             )
 

--- a/apps/backend/src/services/dataset_deletion_service.py
+++ b/apps/backend/src/services/dataset_deletion_service.py
@@ -1,8 +1,7 @@
 from sqlalchemy import MetaData, Table, text
 from sqlmodel import Session, select
 
-from src.core.config import get_data_schema
-from src.core.constants import DEFAULT_DATA_SCHEMA
+from src.core.config import get_data_schema, is_shared_schema
 from src.core.db import data_engine
 from src.core.logging import get_logger
 from src.models.integrity_link import IntegrityLink
@@ -129,11 +128,10 @@ class DatasetDeletionService:
     def _drop_schema_if_empty(self, schema: str) -> None:
         """Drop an org-specific schema only when empty (RESTRICT).
 
-        Never touches the shared schemas: 'staging' and the default data
-        schema (used when USE_ORG_SCHEMA is disabled). Best-effort: a RESTRICT
-        refusal (schema not empty) is the expected harmless outcome.
+        Never touches shared schemas. Best-effort: a RESTRICT refusal
+        (schema not empty) is the expected harmless outcome.
         """
-        if schema in ("staging", DEFAULT_DATA_SCHEMA):
+        if is_shared_schema(schema):
             return
         try:
             with data_engine.connect() as conn:

--- a/apps/backend/src/services/dataset_deletion_service.py
+++ b/apps/backend/src/services/dataset_deletion_service.py
@@ -1,7 +1,8 @@
-from sqlalchemy import MetaData, Table
-from sqlmodel import Session
+from sqlalchemy import MetaData, Table, text
+from sqlmodel import Session, select
 
 from src.core.config import get_data_schema
+from src.core.constants import DEFAULT_DATA_SCHEMA
 from src.core.db import data_engine
 from src.core.logging import get_logger
 from src.models.integrity_link import IntegrityLink
@@ -33,11 +34,13 @@ class DatasetDeletionService:
         Cleanup sequence:
         0. Cancel in-flight DAG runs — best-effort
         1. Delete Airflow DAG — BLOCKING: raises on failure
-        2. Delete GeoServer layer — best-effort
+        2. Delete GeoServer layer + its ACL rules — best-effort
         3. Drop final data table — best-effort
         4. Drop staging table — best-effort
-        5. Delete GeoNetwork record — best-effort
+        5. Delete GeoNetwork record, Airflow run history — best-effort
         6. Delete IntegrityLink from DB (cascades to IntegrityLinkRule)
+        7. If last dataset of the org: delete empty GeoServer datastore/workspace
+           and drop the empty org schema — best-effort
 
         Args:
             integrity_link: The IntegrityLink to delete
@@ -106,9 +109,39 @@ class DatasetDeletionService:
             )
 
         # Step 6: Delete IntegrityLink from DB (ON DELETE CASCADE removes IntegrityLinkRule rows)
+        integrity_link_id = integrity_link.id
+        organization = integrity_link.integrity_organization
         session.delete(integrity_link)
         session.commit()
-        logger.info(f"Deleted IntegrityLink {integrity_link.id}")
+        logger.info(f"Deleted IntegrityLink {integrity_link_id}")
+
+        # Step 7: If this was the org's last dataset, clean up the shared org
+        # resources (best-effort). GeoServer deletes are non-recursive and the
+        # schema drop uses RESTRICT, so anything still in use survives.
+        remaining = session.exec(
+            select(IntegrityLink).where(IntegrityLink.integrity_organization == organization)
+        ).first()
+        if remaining is None:
+            self.geoserver_service.delete_datastore_if_empty(workspace_name, datastore_name)
+            self.geoserver_service.delete_workspace_if_empty(workspace_name)
+            self._drop_schema_if_empty(get_data_schema(workspace_name))
+
+    def _drop_schema_if_empty(self, schema: str) -> None:
+        """Drop an org-specific schema only when empty (RESTRICT).
+
+        Never touches the shared schemas: 'staging' and the default data
+        schema (used when USE_ORG_SCHEMA is disabled). Best-effort: a RESTRICT
+        refusal (schema not empty) is the expected harmless outcome.
+        """
+        if schema in ("staging", DEFAULT_DATA_SCHEMA):
+            return
+        try:
+            with data_engine.connect() as conn:
+                conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" RESTRICT'))
+                conn.commit()
+            logger.info(f"Dropped empty schema {schema}")
+        except Exception as e:
+            logger.info(f"Schema {schema} not dropped (likely not empty): {e}")
 
     def _drop_table_safe(self, schema: str, table_name: str) -> None:
         """Drop a table in the given schema; log and suppress any errors."""

--- a/apps/backend/src/services/dataset_deletion_service.py
+++ b/apps/backend/src/services/dataset_deletion_service.py
@@ -5,7 +5,11 @@ from src.core.config import get_data_schema
 from src.core.db import data_engine
 from src.core.logging import get_logger
 from src.models.integrity_link import IntegrityLink
-from src.services.airflow_client import cancel_ingestion_dag, delete_dag
+from src.services.airflow_client import (
+    cancel_ingestion_dag,
+    delete_dag,
+    purge_dataset_dag_runs,
+)
 from src.services.geoserver import GeoServerService
 from src.services.metadata_service import MetadataService
 
@@ -89,6 +93,17 @@ class DatasetDeletionService:
         # Step 5: Delete GeoNetwork record (best-effort)
         if integrity_link.metadata_id:
             self.metadata_service.delete_record(integrity_link.metadata_id)
+
+        # Step 5b: Purge Airflow run history (dag runs, task instances, XComs)
+        # for this dataset (best-effort). Failed-run log files on the Airflow
+        # volume are out of reach from the backend and are not removed.
+        try:
+            purge_dataset_dag_runs(str(integrity_link.id))
+        except Exception as e:
+            logger.warning(
+                f"Failed to purge Airflow run history for IntegrityLink {integrity_link.id}: {e}",
+                exc_info=True,
+            )
 
         # Step 6: Delete IntegrityLink from DB (ON DELETE CASCADE removes IntegrityLinkRule rows)
         session.delete(integrity_link)

--- a/apps/backend/src/services/dataset_deletion_service.py
+++ b/apps/backend/src/services/dataset_deletion_service.py
@@ -27,7 +27,7 @@ class DatasetDeletionService:
         """Delete a dataset and all associated resources.
 
         Cleanup sequence:
-        1. Delete Airflow DAG (only if schedule set) — BLOCKING: raises on failure
+        1. Delete Airflow DAG — BLOCKING: raises on failure
         2. Delete GeoServer layer — best-effort
         3. Drop final data table — best-effort
         4. Drop staging table — best-effort
@@ -41,15 +41,16 @@ class DatasetDeletionService:
         Raises:
             Exception: If Airflow DAG deletion fails (other cleanup is skipped)
         """
-        # Step 1: Delete Airflow DAG (blocking)
-        if integrity_link.schedule:
-            dag_id = f"ingestion_{integrity_link.id}"
-            try:
-                delete_dag(dag_id)
-                logger.info(f"Deleted Airflow DAG {dag_id}")
-            except Exception as e:
-                logger.error(f"Failed to delete Airflow DAG {dag_id}: {e}", exc_info=True)
-                raise
+        # Step 1: Delete Airflow DAG (blocking). Attempted even when no schedule
+        # is currently set: a previously cleared schedule leaves a stale
+        # ingestion_<id> DAG in Airflow, and delete_dag tolerates 404.
+        dag_id = f"ingestion_{integrity_link.id}"
+        try:
+            delete_dag(dag_id)
+            logger.info(f"Deleted Airflow DAG {dag_id}")
+        except Exception as e:
+            logger.error(f"Failed to delete Airflow DAG {dag_id}: {e}", exc_info=True)
+            raise
 
         workspace_name = integrity_link.integrity_organization.lower()
         datastore_name = f"{workspace_name}_ds"

--- a/apps/backend/src/services/geoserver.py
+++ b/apps/backend/src/services/geoserver.py
@@ -354,6 +354,36 @@ class GeoServerService:
                 exc_info=True,
             )
 
+    def _delete_if_empty(self, url: str, label: str) -> None:
+        """DELETE a GeoServer resource WITHOUT recurse, so the call fails
+        harmlessly when the resource still has children. Best-effort: 404 and
+        refusal statuses are expected; errors are logged and suppressed.
+
+        Note: do NOT use geoservercloud's delete_workspace/delete_datastore —
+        they hardcode recurse=true and would wipe everything underneath.
+        """
+        try:
+            response = self.geoserver.rest_service.rest_client.delete(url)
+            if response.status_code in (200, 204):
+                logger.info(f"Deleted GeoServer {label}")
+            elif response.status_code != 404:
+                logger.info(
+                    f"GeoServer {label} not deleted (status {response.status_code}) "
+                    "— likely not empty"
+                )
+        except Exception as e:
+            logger.error(f"Failed to delete GeoServer {label}: {e}", exc_info=True)
+
+    def delete_datastore_if_empty(self, workspace_name: str, datastore_name: str) -> None:
+        """Delete a datastore only when it has no remaining feature types."""
+        url = self.geoserver.rest_service.rest_endpoints.datastore(workspace_name, datastore_name)
+        self._delete_if_empty(url, f"datastore {workspace_name}/{datastore_name}")
+
+    def delete_workspace_if_empty(self, workspace_name: str) -> None:
+        """Delete a workspace only when it has no remaining stores/layers."""
+        url = self.geoserver.rest_service.rest_endpoints.workspace(workspace_name)
+        self._delete_if_empty(url, f"workspace {workspace_name}")
+
     def delete_layer_acl(self, workspace_name: str, layer_name: str) -> None:
         """Delete the READ and WRITE ACL rules of a layer.
 

--- a/apps/backend/src/services/geoserver.py
+++ b/apps/backend/src/services/geoserver.py
@@ -354,6 +354,29 @@ class GeoServerService:
                 exc_info=True,
             )
 
+    def delete_layer_acl(self, workspace_name: str, layer_name: str) -> None:
+        """Delete the READ and WRITE ACL rules of a layer.
+
+        Treats 404 (rule absent) as success. Logs and suppresses other errors
+        so callers (e.g. dataset deletion) stay best-effort.
+
+        Args:
+            workspace_name: Name of the GeoServer workspace
+            layer_name: Name of the feature type / layer
+        """
+        acl_layer_name = self.make_acl_layer_name(workspace_name, layer_name)
+        for access_type in (AclAccessType.READ, AclAccessType.WRITE):
+            try:
+                self.acl_layer_delete(acl_layer_name, access_type)
+            except GeoServerAclError as e:
+                if e.status_code != 404:
+                    logger.error(f"Failed to delete ACL rule {acl_layer_name}.{access_type}: {e}")
+            except Exception as e:
+                logger.error(
+                    f"Failed to delete ACL rule {acl_layer_name}.{access_type}: {e}",
+                    exc_info=True,
+                )
+
     @staticmethod
     def _to_geoserver_role(role: str) -> str:
         """Ensure role name has ROLE_ prefix as required by GeoServer ACL.

--- a/apps/backend/tests/core/test_config.py
+++ b/apps/backend/tests/core/test_config.py
@@ -1,0 +1,22 @@
+"""Tests for schema helpers in core config."""
+
+from unittest.mock import patch
+
+from src.core.config import is_shared_schema
+
+
+class TestIsSharedSchema:
+    def test_staging_schema_is_shared(self) -> None:
+        assert is_shared_schema("staging")
+
+    def test_default_data_schema_is_shared(self) -> None:
+        assert is_shared_schema("data")
+
+    def test_org_schema_is_not_shared(self) -> None:
+        assert not is_shared_schema("myorg")
+
+    def test_follows_configured_staging_schema(self) -> None:
+        """The guard tracks get_staging_schema, not a hardcoded literal."""
+        with patch("src.core.config.get_staging_schema", return_value="staging_v2"):
+            assert is_shared_schema("staging_v2")
+            assert not is_shared_schema("staging")

--- a/apps/backend/tests/services/test_airflow_client.py
+++ b/apps/backend/tests/services/test_airflow_client.py
@@ -6,6 +6,7 @@ import pytest
 from airflow_client.client.exceptions import ConflictException, NotFoundException
 
 from src.services.airflow_client import (
+    _delete_dag_runs,  # pyright: ignore[reportPrivateUsage]
     _force_fail_dag_runs,  # pyright: ignore[reportPrivateUsage]
     _get_cached_airflow_api_client,  # pyright: ignore[reportPrivateUsage]
     _get_cached_dag_api,  # pyright: ignore[reportPrivateUsage]
@@ -18,6 +19,7 @@ from src.services.airflow_client import (
     get_airflow_api_client,
     get_dag_api,
     get_dag_run_api,
+    purge_dataset_dag_runs,
 )
 
 
@@ -549,3 +551,63 @@ class TestCancelIngestionDag:
         mock_force_fail.assert_any_call("process_dag", dag_run_id_prefix="abc-123_")
         mock_force_fail.assert_any_call("staging_dag", dag_run_id_prefix="abc-123")
         assert mock_force_fail.call_count == 3
+
+
+class TestPurgeDatasetDagRuns:
+    def _mock_api(self, pages: list[list[str]]) -> Mock:
+        """Build a DagRunApi mock returning the given run-id pages then empty."""
+        api = Mock()
+        responses = []
+        total = sum(len(p) for p in pages)
+        for page in pages:
+            responses.append(
+                Mock(dag_runs=[Mock(dag_run_id=run_id) for run_id in page], total_entries=total)
+            )
+        responses.append(Mock(dag_runs=[], total_entries=0))
+        api.get_dag_runs.side_effect = responses
+        return api
+
+    def test_deletes_staging_and_process_runs(self) -> None:
+        """Runs of both shared DAGs matching the dataset prefix are deleted."""
+        api = Mock()
+        api.get_dag_runs.side_effect = [
+            Mock(dag_runs=[Mock(dag_run_id="abc-123")], total_entries=1),
+            Mock(dag_runs=[], total_entries=0),
+            Mock(dag_runs=[Mock(dag_run_id="abc-123_456")], total_entries=1),
+            Mock(dag_runs=[], total_entries=0),
+        ]
+        with patch("src.services.airflow_client.get_dag_run_api", return_value=api):
+            purge_dataset_dag_runs("abc-123")
+
+        api.delete_dag_run.assert_any_call(dag_id="staging_dag", dag_run_id="abc-123")
+        api.delete_dag_run.assert_any_call(dag_id="process_dag", dag_run_id="abc-123_456")
+        # LIKE patterns: staging matches '<id>%', process matches '<id>_%'
+        patterns = [c.kwargs["run_id_pattern"] for c in api.get_dag_runs.call_args_list]
+        assert "abc-123%" in patterns
+        assert "abc-123_%" in patterns
+
+    def test_missing_dag_is_swallowed(self) -> None:
+        api = Mock()
+        api.get_dag_runs.side_effect = NotFoundException()
+        with patch("src.services.airflow_client.get_dag_run_api", return_value=api):
+            purge_dataset_dag_runs("abc-123")  # must not raise
+
+        api.delete_dag_run.assert_not_called()
+
+    def test_delete_failures_do_not_abort_or_loop_forever(self) -> None:
+        """A run that cannot be deleted is skipped without raising or looping."""
+        api = Mock()
+        api.get_dag_runs.return_value = Mock(
+            dag_runs=[Mock(dag_run_id="abc-123_1")], total_entries=1
+        )
+        api.delete_dag_run.side_effect = Exception("boom")
+        with patch("src.services.airflow_client.get_dag_run_api", return_value=api):
+            purge_dataset_dag_runs("abc-123")  # must not raise
+
+    def test_paginates_until_no_runs_remain(self) -> None:
+        api = self._mock_api([["abc-123_1", "abc-123_2"], ["abc-123_3"]])
+        # Only purge one dag to keep the side_effect sequence simple
+        with patch("src.services.airflow_client.get_dag_run_api", return_value=api):
+            _delete_dag_runs("process_dag", "abc-123_%")
+
+        assert api.delete_dag_run.call_count == 3

--- a/apps/backend/tests/services/test_airflow_client.py
+++ b/apps/backend/tests/services/test_airflow_client.py
@@ -13,6 +13,7 @@ from src.services.airflow_client import (
     _is_jwt_expired,  # pyright: ignore[reportPrivateUsage]
     _refresh_caches_if_token_expired,  # pyright: ignore[reportPrivateUsage]
     _request_new_access_token,  # pyright: ignore[reportPrivateUsage]
+    cancel_ingestion_dag,
     delete_dag,
     get_airflow_api_client,
     get_dag_api,
@@ -535,3 +536,16 @@ class TestForceFail:
 
             _force_fail_dag_runs("ingestion_123")  # must not raise
             mock_run_api.patch_dag_run.assert_not_called()
+
+
+class TestCancelIngestionDag:
+    def test_force_fails_ingestion_process_and_staging_runs(self) -> None:
+        """All in-flight runs of the dataset are force-failed: the scheduled
+        ingestion DAG, plus process_dag and staging_dag runs by run-id prefix."""
+        with patch("src.services.airflow_client._force_fail_dag_runs") as mock_force_fail:
+            cancel_ingestion_dag("abc-123")
+
+        mock_force_fail.assert_any_call("ingestion_abc-123")
+        mock_force_fail.assert_any_call("process_dag", dag_run_id_prefix="abc-123_")
+        mock_force_fail.assert_any_call("staging_dag", dag_run_id_prefix="abc-123")
+        assert mock_force_fail.call_count == 3

--- a/apps/backend/tests/services/test_dataset_deletion_service.py
+++ b/apps/backend/tests/services/test_dataset_deletion_service.py
@@ -34,6 +34,13 @@ def mock_cancel_runs():
         yield mock
 
 
+@pytest.fixture(autouse=True)
+def mock_purge_runs():
+    """delete_dataset purges the Airflow run history; keep it mocked everywhere."""
+    with patch("src.services.dataset_deletion_service.purge_dataset_dag_runs") as mock:
+        yield mock
+
+
 @pytest.fixture
 def geoserver_svc() -> MagicMock:
     svc = MagicMock()
@@ -256,6 +263,46 @@ class TestCancelInFlightRuns:
     ) -> None:
         """A cancellation failure (Airflow hiccup) must not abort the deletion."""
         mock_cancel_runs.side_effect = Exception("airflow down")
+        link = _make_link()
+        session = MagicMock()
+
+        with patch("src.services.dataset_deletion_service.Table"):
+            deletion_service.delete_dataset(link, session)
+
+        session.delete.assert_called_once_with(link)
+
+
+class TestPurgeRunHistory:
+    """Airflow run history is purged before the IntegrityLink row is deleted."""
+
+    @patch("src.services.dataset_deletion_service.data_engine")
+    @patch("src.services.dataset_deletion_service.delete_dag")
+    def test_purges_run_history(
+        self,
+        mock_delete_dag: MagicMock,
+        mock_data_engine: MagicMock,
+        deletion_service: DatasetDeletionService,
+        mock_purge_runs: MagicMock,
+    ) -> None:
+        link = _make_link()
+        session = MagicMock()
+
+        with patch("src.services.dataset_deletion_service.Table"):
+            deletion_service.delete_dataset(link, session)
+
+        mock_purge_runs.assert_called_once_with("00000000-0000-0000-0000-000000000001")
+
+    @patch("src.services.dataset_deletion_service.data_engine")
+    @patch("src.services.dataset_deletion_service.delete_dag")
+    def test_purge_failure_is_best_effort(
+        self,
+        mock_delete_dag: MagicMock,
+        mock_data_engine: MagicMock,
+        deletion_service: DatasetDeletionService,
+        mock_purge_runs: MagicMock,
+    ) -> None:
+        """A purge failure must not abort the row deletion."""
+        mock_purge_runs.side_effect = Exception("airflow down")
         link = _make_link()
         session = MagicMock()
 

--- a/apps/backend/tests/services/test_dataset_deletion_service.py
+++ b/apps/backend/tests/services/test_dataset_deletion_service.py
@@ -89,20 +89,21 @@ class TestDatasetDeletionService:
 
     @patch("src.services.dataset_deletion_service.data_engine")
     @patch("src.services.dataset_deletion_service.delete_dag")
-    def test_happy_path_without_schedule(
+    def test_dag_deleted_even_without_schedule(
         self,
         mock_delete_dag: MagicMock,
         mock_data_engine: MagicMock,
         deletion_service: DatasetDeletionService,
     ) -> None:
-        """Without schedule: no DAG deletion attempted."""
+        """Without schedule: DAG deletion is still attempted (stale DAGs from a
+        previously cleared schedule must be removed; 404 is tolerated)."""
         link = _make_link(schedule=None)
         session = MagicMock()
 
         with patch("src.services.dataset_deletion_service.Table"):
             deletion_service.delete_dataset(link, session)
 
-        mock_delete_dag.assert_not_called()
+        mock_delete_dag.assert_called_once_with("ingestion_00000000-0000-0000-0000-000000000001")
 
     @patch("src.services.dataset_deletion_service.data_engine")
     @patch("src.services.dataset_deletion_service.delete_dag")

--- a/apps/backend/tests/services/test_dataset_deletion_service.py
+++ b/apps/backend/tests/services/test_dataset_deletion_service.py
@@ -27,6 +27,13 @@ def _make_link(
     return link
 
 
+@pytest.fixture(autouse=True)
+def mock_cancel_runs():
+    """delete_dataset cancels in-flight runs first; keep it mocked everywhere."""
+    with patch("src.services.dataset_deletion_service.cancel_ingestion_dag") as mock:
+        yield mock
+
+
 @pytest.fixture
 def geoserver_svc() -> MagicMock:
     svc = MagicMock()
@@ -215,4 +222,44 @@ class TestDatasetDeletionService:
             deletion_service.delete_dataset(link, session)
 
         metadata_svc.delete_record.assert_not_called()
+        session.delete.assert_called_once_with(link)
+
+
+class TestCancelInFlightRuns:
+    """In-flight DAG runs are cancelled before any resource is removed."""
+
+    @patch("src.services.dataset_deletion_service.data_engine")
+    @patch("src.services.dataset_deletion_service.delete_dag")
+    def test_cancels_runs_for_the_dataset(
+        self,
+        mock_delete_dag: MagicMock,
+        mock_data_engine: MagicMock,
+        deletion_service: DatasetDeletionService,
+        mock_cancel_runs: MagicMock,
+    ) -> None:
+        link = _make_link()
+        session = MagicMock()
+
+        with patch("src.services.dataset_deletion_service.Table"):
+            deletion_service.delete_dataset(link, session)
+
+        mock_cancel_runs.assert_called_once_with("00000000-0000-0000-0000-000000000001")
+
+    @patch("src.services.dataset_deletion_service.data_engine")
+    @patch("src.services.dataset_deletion_service.delete_dag")
+    def test_cancel_failure_is_best_effort(
+        self,
+        mock_delete_dag: MagicMock,
+        mock_data_engine: MagicMock,
+        deletion_service: DatasetDeletionService,
+        mock_cancel_runs: MagicMock,
+    ) -> None:
+        """A cancellation failure (Airflow hiccup) must not abort the deletion."""
+        mock_cancel_runs.side_effect = Exception("airflow down")
+        link = _make_link()
+        session = MagicMock()
+
+        with patch("src.services.dataset_deletion_service.Table"):
+            deletion_service.delete_dataset(link, session)
+
         session.delete.assert_called_once_with(link)

--- a/apps/backend/tests/services/test_dataset_deletion_service.py
+++ b/apps/backend/tests/services/test_dataset_deletion_service.py
@@ -78,6 +78,10 @@ class TestDatasetDeletionService:
             datastore_name="testorg_ds",
             layer_name="my_table",
         )
+        geoserver_svc.delete_layer_acl.assert_called_once_with(
+            workspace_name="testorg",
+            layer_name="my_table",
+        )
         assert mock_table.drop.call_count == 2  # final table + staging table
         metadata_svc.delete_record.assert_called_once_with("uuid-meta-1")
         session.delete.assert_called_once_with(link)
@@ -164,6 +168,7 @@ class TestDatasetDeletionService:
             deletion_service.delete_dataset(link, session)
 
         geoserver_svc.delete_layer.assert_not_called()
+        geoserver_svc.delete_layer_acl.assert_not_called()
         # Only staging table drop should be attempted (1 call)
         assert mock_table.drop.call_count == 1
 

--- a/apps/backend/tests/services/test_dataset_deletion_service.py
+++ b/apps/backend/tests/services/test_dataset_deletion_service.py
@@ -310,3 +310,96 @@ class TestPurgeRunHistory:
             deletion_service.delete_dataset(link, session)
 
         session.delete.assert_called_once_with(link)
+
+
+class TestOrgResourceCleanup:
+    """Shared org resources are cleaned up when the last dataset is removed."""
+
+    @patch("src.services.dataset_deletion_service.get_data_schema", return_value="testorg")
+    @patch("src.services.dataset_deletion_service.data_engine")
+    @patch("src.services.dataset_deletion_service.delete_dag")
+    def test_last_dataset_triggers_cleanup(
+        self,
+        mock_delete_dag: MagicMock,
+        mock_data_engine: MagicMock,
+        mock_get_schema: MagicMock,
+        deletion_service: DatasetDeletionService,
+        geoserver_svc: MagicMock,
+    ) -> None:
+        link = _make_link()
+        session = MagicMock()
+        session.exec.return_value.first.return_value = None  # no dataset left for the org
+
+        with patch("src.services.dataset_deletion_service.Table"):
+            deletion_service.delete_dataset(link, session)
+
+        geoserver_svc.delete_datastore_if_empty.assert_called_once_with("testorg", "testorg_ds")
+        geoserver_svc.delete_workspace_if_empty.assert_called_once_with("testorg")
+        # Org schema drop attempted (RESTRICT — harmless when not empty)
+        mock_data_engine.connect.assert_called()
+
+    @patch("src.services.dataset_deletion_service.get_data_schema", return_value="testorg")
+    @patch("src.services.dataset_deletion_service.data_engine")
+    @patch("src.services.dataset_deletion_service.delete_dag")
+    def test_remaining_datasets_skip_cleanup(
+        self,
+        mock_delete_dag: MagicMock,
+        mock_data_engine: MagicMock,
+        mock_get_schema: MagicMock,
+        deletion_service: DatasetDeletionService,
+        geoserver_svc: MagicMock,
+    ) -> None:
+        link = _make_link()
+        session = MagicMock()
+        session.exec.return_value.first.return_value = MagicMock()  # another dataset remains
+
+        with patch("src.services.dataset_deletion_service.Table"):
+            deletion_service.delete_dataset(link, session)
+
+        geoserver_svc.delete_datastore_if_empty.assert_not_called()
+        geoserver_svc.delete_workspace_if_empty.assert_not_called()
+
+    @patch("src.services.dataset_deletion_service.get_data_schema", return_value="data")
+    @patch("src.services.dataset_deletion_service.data_engine")
+    @patch("src.services.dataset_deletion_service.delete_dag")
+    def test_shared_data_schema_is_never_dropped(
+        self,
+        mock_delete_dag: MagicMock,
+        mock_data_engine: MagicMock,
+        mock_get_schema: MagicMock,
+        deletion_service: DatasetDeletionService,
+        geoserver_svc: MagicMock,
+    ) -> None:
+        """USE_ORG_SCHEMA=False → schema is the shared 'data' schema: never drop
+        it; GeoServer workspace/datastore cleanup still applies."""
+        link = _make_link()
+        session = MagicMock()
+        session.exec.return_value.first.return_value = None
+
+        with patch("src.services.dataset_deletion_service.Table"):
+            deletion_service.delete_dataset(link, session)
+
+        geoserver_svc.delete_workspace_if_empty.assert_called_once_with("testorg")
+        mock_data_engine.connect.assert_not_called()
+
+    @patch("src.services.dataset_deletion_service.get_data_schema", return_value="testorg")
+    @patch("src.services.dataset_deletion_service.data_engine")
+    @patch("src.services.dataset_deletion_service.delete_dag")
+    def test_cleanup_failure_is_best_effort(
+        self,
+        mock_delete_dag: MagicMock,
+        mock_data_engine: MagicMock,
+        mock_get_schema: MagicMock,
+        deletion_service: DatasetDeletionService,
+        geoserver_svc: MagicMock,
+    ) -> None:
+        """RESTRICT refusal (schema not empty) must not raise; row already deleted."""
+        link = _make_link()
+        session = MagicMock()
+        session.exec.return_value.first.return_value = None
+        mock_data_engine.connect.side_effect = Exception("schema not empty")
+
+        with patch("src.services.dataset_deletion_service.Table"):
+            deletion_service.delete_dataset(link, session)  # must not raise
+
+        session.delete.assert_called_once_with(link)

--- a/apps/backend/tests/services/test_geoserver.py
+++ b/apps/backend/tests/services/test_geoserver.py
@@ -875,3 +875,77 @@ class TestDeleteLayerAcl:
         service.delete_layer_acl("myorg", "my_table")
 
         assert service.acl_layer_delete.call_count == 2
+
+
+class TestDeleteIfEmpty:
+    """Tests for delete_datastore_if_empty / delete_workspace_if_empty."""
+
+    @pytest.fixture
+    def service(self) -> GeoServerService:
+        with patch("src.services.geoserver.GeoServerCloud"):
+            svc = GeoServerService(
+                base_url="http://test.example.com/geoserver",
+                username="testuser",
+                password="testpass",
+                public_url="http://test.example.com",
+            )
+            svc.geoserver = MagicMock()
+            return svc
+
+    @pytest.fixture
+    def rest_client(self, service: GeoServerService) -> MagicMock:
+        client = MagicMock()
+        service.geoserver.rest_service.rest_client = client
+        return client
+
+    @pytest.fixture
+    def rest_endpoints(self, service: GeoServerService) -> MagicMock:
+        endpoints = MagicMock()
+        service.geoserver.rest_service.rest_endpoints = endpoints
+        return endpoints
+
+    def test_datastore_deleted_without_recurse(
+        self, service: GeoServerService, rest_client: MagicMock, rest_endpoints: MagicMock
+    ) -> None:
+        """The DELETE call must NOT pass recurse — non-empty stores must survive."""
+        rest_endpoints.datastore.return_value = "/rest/workspaces/org/datastores/org_ds.json"
+        rest_client.delete.return_value.status_code = 200
+
+        service.delete_datastore_if_empty("org", "org_ds")
+
+        rest_endpoints.datastore.assert_called_once_with("org", "org_ds")
+        rest_client.delete.assert_called_once_with("/rest/workspaces/org/datastores/org_ds.json")
+
+    def test_workspace_deleted_without_recurse(
+        self, service: GeoServerService, rest_client: MagicMock, rest_endpoints: MagicMock
+    ) -> None:
+        rest_endpoints.workspace.return_value = "/rest/workspaces/org.json"
+        rest_client.delete.return_value.status_code = 200
+
+        service.delete_workspace_if_empty("org")
+
+        rest_endpoints.workspace.assert_called_once_with("org")
+        rest_client.delete.assert_called_once_with("/rest/workspaces/org.json")
+
+    def test_non_empty_resource_failure_is_swallowed(
+        self, service: GeoServerService, rest_client: MagicMock, rest_endpoints: MagicMock
+    ) -> None:
+        """GeoServer refuses to delete non-empty resources (403/500) — harmless."""
+        rest_client.delete.return_value.status_code = 403
+
+        service.delete_workspace_if_empty("org")  # must not raise
+        service.delete_datastore_if_empty("org", "org_ds")  # must not raise
+
+    def test_missing_resource_is_swallowed(
+        self, service: GeoServerService, rest_client: MagicMock, rest_endpoints: MagicMock
+    ) -> None:
+        rest_client.delete.return_value.status_code = 404
+
+        service.delete_workspace_if_empty("org")  # must not raise
+
+    def test_network_error_is_swallowed(
+        self, service: GeoServerService, rest_client: MagicMock, rest_endpoints: MagicMock
+    ) -> None:
+        rest_client.delete.side_effect = Exception("connection refused")
+
+        service.delete_workspace_if_empty("org")  # must not raise

--- a/apps/backend/tests/services/test_geoserver.py
+++ b/apps/backend/tests/services/test_geoserver.py
@@ -831,3 +831,47 @@ class TestUpdateLayerTitle:
         rest_client.put.return_value.status_code = 201
 
         service.update_layer_title("myws", "myds", "my_table", "Title")
+
+
+class TestDeleteLayerAcl:
+    """Tests for delete_layer_acl (full ACL cleanup of a layer)."""
+
+    @pytest.fixture
+    def service(self) -> GeoServerService:
+        with patch("src.services.geoserver.GeoServerCloud"):
+            svc = GeoServerService(
+                base_url="http://test.example.com/geoserver",
+                username="testuser",
+                password="testpass",
+                public_url="http://test.example.com",
+            )
+            svc.geoserver = MagicMock()
+            return svc
+
+    def test_deletes_read_and_write_rules(self, service: GeoServerService) -> None:
+        """Both the .r and .w ACL rules of the layer are deleted."""
+        service.acl_layer_delete = MagicMock()
+
+        service.delete_layer_acl("MyOrg", "my_table")
+
+        service.acl_layer_delete.assert_any_call("myorg.my_table", AclAccessType.READ)
+        service.acl_layer_delete.assert_any_call("myorg.my_table", AclAccessType.WRITE)
+        assert service.acl_layer_delete.call_count == 2
+
+    def test_404_treated_as_success(self, service: GeoServerService) -> None:
+        """Absent rules (404) are not an error and both deletions are attempted."""
+        service.acl_layer_delete = MagicMock(side_effect=GeoServerAclError(404, "Not found"))
+
+        service.delete_layer_acl("myorg", "my_table")
+
+        assert service.acl_layer_delete.call_count == 2
+
+    def test_other_errors_are_best_effort(self, service: GeoServerService) -> None:
+        """Non-404 errors are logged and suppressed; the WRITE rule is still attempted."""
+        service.acl_layer_delete = MagicMock(
+            side_effect=[GeoServerAclError(500, "boom"), Exception("network")]
+        )
+
+        service.delete_layer_acl("myorg", "my_table")
+
+        assert service.acl_layer_delete.call_count == 2


### PR DESCRIPTION
Audit of what each action creates vs. what deletion cleaned up — the gaps found on the deletion path, fixed:

- **GeoServer ACL rules:** deletion removed the feature type but left its `.r`/`.w` rules. Since `final_table_name` is reused by `get_available_table_name`, old rules could silently apply to a future dataset. `delete_layer_acl` is now called alongside `delete_layer` (best-effort, 404-tolerant).
- **In-flight runs:** no runs were cancelled before deletion; a run finishing afterwards would recreate tables with nothing tracking them. `cancel_ingestion_dag` now force-fails the scheduled ingestion DAG, `process_dag` and `staging_dag` runs first.
- **Stale ingestion DAG:** the `ingestion_<id>` DAG was only deleted when a schedule was still set at deletion time. Deletion now always calls `delete_dag` (404-tolerant).
- **Run history:** `staging_dag`/`process_dag` run records (dag runs, task instances, XComs carrying table names) were never removed. `purge_dataset_dag_runs` deletes them via `run_id_pattern` LIKE before the IntegrityLink row is deleted.
- **Org-shared resources:** the GeoServer workspace `{org}`, datastore `{org}_ds` and the org PostgreSQL schema outlived all datasets forever. After the last dataset of an org is deleted, the service attempts (best-effort) non-recursive REST deletes (GeoServer refuses when non-empty → harmless) and `DROP SCHEMA … RESTRICT` (skipped for shared `staging`/`data` schemas, guard co-located with the schema config).

> **Known limitation:** failed-run log files on the Airflow volume are unreachable from the backend and remain.
