### PR TITLE
Fix: delete temp upload file on staging failure

### DIFF
--- a/apps/backend/src/api/routes/ingestion/staging.py
+++ b/apps/backend/src/api/routes/ingestion/staging.py
@@ -698,16 +698,12 @@ def dag_success_callback(
     session.commit()
     session.refresh(integrity_link)
 
-    try:
-        # db:// URIs and service URLs are not temp files — only delete for FILE/URL/FTP sources
-        if integrity_link.source_url and integrity_link.source_import_type not in (
-            ImportType.DATABASE,
-            ImportType.API,
-        ):
+    # Clean temp file
+    if integrity_link.source_url and integrity_link.source_import_type == ImportType.FILE:
+        try:
             delete_temp_file(integrity_link.source_url)
-    except Exception as e:
-        logger.error(f"Error deleting temp file: {e}")
-
+        except Exception as e:
+            logger.error(f"Error deleting temp file: {e}")
 
 @router.post("/dag_failure")
 def dag_failure_callback(
@@ -742,6 +738,13 @@ def dag_failure_callback(
     integrity_link = datafeeder_session.get(IntegrityLink, UUID(integrity_link_id))
     if not integrity_link:
         raise HTTPException(status_code=404, detail="IntegrityLink not found")
+
+    # Clean temp file
+    if integrity_link.source_url and integrity_link.source_import_type == ImportType.FILE:
+        try:
+            delete_temp_file(integrity_link.source_url)
+        except Exception as e:
+            logger.error(f"Error deleting temp file: {e}")
 
     is_rerun = integrity_link.last_retrieval_timestamp is not None  # it is a rerun/reconfig
 

--- a/apps/backend/src/api/routes/ingestion/staging.py
+++ b/apps/backend/src/api/routes/ingestion/staging.py
@@ -668,6 +668,19 @@ async def edit_staging(
     )
 
 
+def _delete_temp_source_file(integrity_link: IntegrityLink) -> None:
+    """Delete the temp upload file of a FILE-sourced dataset, best-effort.
+
+    Only FILE imports create a temp file; URL/FTP/DATABASE/API source_urls
+    point at external sources and must not be touched.
+    """
+    if integrity_link.source_url and integrity_link.source_import_type == ImportType.FILE:
+        try:
+            delete_temp_file(integrity_link.source_url)
+        except Exception as e:
+            logger.error(f"Error deleting temp file: {e}")
+
+
 @router.post("/dag_success")
 def dag_success_callback(
     session: DatafeederSessionDep,
@@ -698,12 +711,8 @@ def dag_success_callback(
     session.commit()
     session.refresh(integrity_link)
 
-    # Clean temp file
-    if integrity_link.source_url and integrity_link.source_import_type == ImportType.FILE:
-        try:
-            delete_temp_file(integrity_link.source_url)
-        except Exception as e:
-            logger.error(f"Error deleting temp file: {e}")
+    _delete_temp_source_file(integrity_link)
+
 
 @router.post("/dag_failure")
 def dag_failure_callback(
@@ -739,12 +748,7 @@ def dag_failure_callback(
     if not integrity_link:
         raise HTTPException(status_code=404, detail="IntegrityLink not found")
 
-    # Clean temp file
-    if integrity_link.source_url and integrity_link.source_import_type == ImportType.FILE:
-        try:
-            delete_temp_file(integrity_link.source_url)
-        except Exception as e:
-            logger.error(f"Error deleting temp file: {e}")
+    _delete_temp_source_file(integrity_link)
 
     is_rerun = integrity_link.last_retrieval_timestamp is not None  # it is a rerun/reconfig
 

--- a/apps/backend/tests/api/routes/test_staging_api.py
+++ b/apps/backend/tests/api/routes/test_staging_api.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 
 from src.api.routes.ingestion.staging import (
     _process_import_source,  # pyright: ignore[reportPrivateUsage]
+    dag_failure_callback,
     dag_success_callback,
     edit_staging,
     get_staging_metadata,
@@ -402,3 +403,128 @@ class TestOapifUrlNormalization:
             service_protocol="ogcFeatures",
         )
         assert result.url == "https://example.com/v1"
+
+
+class TestDagSuccessCallbackTempFile:
+    """Test temp upload file cleanup in the staging success callback."""
+
+    def _call(self, import_type: ImportType, source_url: str) -> None:
+        link = MagicMock()
+        link.source_url = source_url
+        link.source_import_type = import_type
+        link.created_at = datetime.now(timezone.utc)
+
+        session = MagicMock()
+        session.get.return_value = link
+
+        dag_success_callback(session=session, integrity_link_id=str(uuid4()))
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_temp_file_deleted_for_file_import(self, mock_delete: MagicMock) -> None:
+        url = "http://backend:8000/internal/files/data_abc.gpkg"
+
+        self._call(ImportType.FILE, url)
+
+        mock_delete.assert_called_once_with(url)
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_temp_file_not_deleted_for_url_import(self, mock_delete: MagicMock) -> None:
+        self._call(ImportType.URL, "https://example.com/data.gpkg")
+
+        mock_delete.assert_not_called()
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_temp_file_not_deleted_for_ftp_import(self, mock_delete: MagicMock) -> None:
+        self._call(ImportType.FTP, "ftp://host:21/data.gpkg")
+
+        mock_delete.assert_not_called()
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_temp_file_not_deleted_for_database_import(self, mock_delete: MagicMock) -> None:
+        self._call(ImportType.DATABASE, "db://main/public/my_table")
+
+        mock_delete.assert_not_called()
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_delete_error_is_swallowed(self, mock_delete: MagicMock) -> None:
+        mock_delete.side_effect = IOError("already gone")
+
+        self._call(ImportType.FILE, "http://backend:8000/internal/files/data_abc.gpkg")  # no raise
+
+
+class TestDagFailureCallbackTempFile:
+    """Test temp upload file cleanup in the staging failure callback."""
+
+    def _make_link(
+        self,
+        import_type: ImportType,
+        last_retrieval: datetime | None = None,
+    ) -> MagicMock:
+        link = MagicMock()
+        link.source_url = "http://backend:8000/internal/files/data_abc.gpkg"
+        link.source_import_type = import_type
+        link.staging_table_name = "staging_abc"
+        link.last_retrieval_timestamp = last_retrieval
+        return link
+
+    def _call(self, link: MagicMock) -> tuple[MagicMock, MagicMock]:
+        datafeeder_session = MagicMock()
+        datafeeder_session.get.return_value = link
+        data_session = MagicMock()
+
+        with (
+            patch("src.api.routes.ingestion.staging.Table"),
+            patch("src.api.routes.ingestion.staging.data_engine"),
+        ):
+            dag_failure_callback(
+                datafeeder_session=datafeeder_session,
+                data_session=data_session,
+                integrity_link_id=str(uuid4()),
+                dag_id="staging_dag",
+                dag_run_id="run-1",
+                reason=None,
+            )
+        return datafeeder_session, data_session
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_temp_file_deleted_for_file_import(self, mock_delete: MagicMock) -> None:
+        link = self._make_link(ImportType.FILE)
+
+        datafeeder_session, _ = self._call(link)
+
+        mock_delete.assert_called_once_with(link.source_url)
+        datafeeder_session.delete.assert_called_once_with(link)
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_temp_file_not_deleted_for_database_import(self, mock_delete: MagicMock) -> None:
+        link = self._make_link(ImportType.DATABASE)
+
+        self._call(link)
+
+        mock_delete.assert_not_called()
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_temp_file_not_deleted_for_api_import(self, mock_delete: MagicMock) -> None:
+        link = self._make_link(ImportType.API)
+
+        self._call(link)
+
+        mock_delete.assert_not_called()
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_temp_file_deleted_on_rerun_but_link_kept(self, mock_delete: MagicMock) -> None:
+        link = self._make_link(ImportType.FILE, last_retrieval=datetime.now(timezone.utc))
+
+        datafeeder_session, _ = self._call(link)
+
+        mock_delete.assert_called_once_with(link.source_url)
+        datafeeder_session.delete.assert_not_called()
+
+    @patch("src.api.routes.ingestion.staging.delete_temp_file")
+    def test_delete_error_does_not_abort_cleanup(self, mock_delete: MagicMock) -> None:
+        mock_delete.side_effect = IOError("already gone")
+        link = self._make_link(ImportType.FILE)
+
+        datafeeder_session, _ = self._call(link)
+
+        datafeeder_session.delete.assert_called_once_with(link)


### PR DESCRIPTION
**Before:** the temp upload file (FILE imports) was deleted only in the staging success callback. A staging failure left it in `TMP_UPLOAD_PATH` with nothing referencing it.

**After:** the staging failure callback also calls `delete_temp_file` (best-effort, same DATABASE/API type guard as the success path). The cleanup logic is extracted into a shared helper used by both callbacks.
