### PR TITLE
Update config with renaming internal variables

### DIFF
--- a/apps/backend/datafeeder.env
+++ b/apps/backend/datafeeder.env
@@ -1,5 +1,5 @@
 # Used to override default values in config.py
-BACKEND_URL=http://host.docker.internal:8000
+BACKEND_INTERNAL_URL=http://host.docker.internal:8000
 TMP_UPLOAD_PATH=/tmp/
 ENCRYPTION_KEY=your_encryption_key
 POSTGRES_DATA_HOST=localhost

--- a/apps/backend/src/api/deps.py
+++ b/apps/backend/src/api/deps.py
@@ -140,7 +140,7 @@ GroupIdsDep = Annotated[list[str], Depends(get_group_ids)]
 def get_geoserver_service() -> GeoServerService:
     settings = get_settings()
     return GeoServerService(
-        base_url=settings.GEOSERVER_URL,
+        base_url=settings.GEOSERVER_INTERNAL_URL,
         username=settings.GEOSERVER_USER,
         password=settings.GEOSERVER_PASSWORD,
         public_url=settings.DATA_PUBLIC_URL,

--- a/apps/backend/src/api/deps.py
+++ b/apps/backend/src/api/deps.py
@@ -49,7 +49,7 @@ def get_org_id(geo_ctx: GeorchestraContextDep) -> str | None:
     if not geo_ctx.organization:
         return None
 
-    service = ConsoleService(get_settings().CONSOLE_URL)
+    service = ConsoleService(get_settings().CONSOLE_INTERNAL_URL)
     org = service.get_organization(geo_ctx.organization)
 
     return str(org["id"]) if org and "id" in org else None
@@ -106,7 +106,7 @@ def get_group_ids(geo_ctx: GeorchestraContextDep) -> list[str]:
         # becomes hot, promote ConsoleService to a request-scoped FastAPI dep
         # and memoize get_all_roles on the instance so rule-sync paths share it.
         try:
-            all_roles = ConsoleService(settings.CONSOLE_URL).get_all_roles()
+            all_roles = ConsoleService(settings.CONSOLE_INTERNAL_URL).get_all_roles()
         except ConsoleServiceError as exc:
             logger.warning(
                 "Console unreachable while resolving role UUIDs; "
@@ -126,7 +126,7 @@ def get_group_ids(geo_ctx: GeorchestraContextDep) -> list[str]:
 
     if not geo_ctx.organization:
         return []
-    org = ConsoleService(settings.CONSOLE_URL).get_organization(geo_ctx.organization)
+    org = ConsoleService(settings.CONSOLE_INTERNAL_URL).get_organization(geo_ctx.organization)
     if not org or "id" not in org:
         return []
     if not _matches_metadata_filter(str(org.get("name", "")), pattern):

--- a/apps/backend/src/api/routes/data_groups.py
+++ b/apps/backend/src/api/routes/data_groups.py
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/data/groups", tags=["Data"])
 )
 def list_groups(geo_ctx: GeorchestraContextDep) -> list[GroupItem]:
     settings = get_settings()
-    console_service = ConsoleService(settings.CONSOLE_URL)
+    console_service = ConsoleService(settings.CONSOLE_INTERNAL_URL)
 
     try:
         items = console_service.get_all_roles()

--- a/apps/backend/src/api/routes/geonetwork.py
+++ b/apps/backend/src/api/routes/geonetwork.py
@@ -71,7 +71,7 @@ async def proxy_geonetwork(path: str, request: Request) -> Response:
     settings = get_settings()
 
     # Build upstream URL
-    upstream_base = settings.GEONETWORK_URL.rstrip("/")
+    upstream_base = settings.GEONETWORK_INTERNAL_URL.rstrip("/")
     upstream_url = f"{upstream_base}/{path}"
 
     # Preserve query string

--- a/apps/backend/src/api/routes/ingestion/empty_dataset.py
+++ b/apps/backend/src/api/routes/ingestion/empty_dataset.py
@@ -61,7 +61,7 @@ def create_empty_dataset(
             user_last_name = geo_ctx.lastname
 
         metadata_service = MetadataService(
-            gn_api_url=f"{settings.GEONETWORK_URL}/srv/api",
+            gn_api_url=f"{settings.GEONETWORK_INTERNAL_URL}/srv/api",
             datadir_path=settings.DATADIR_PATH,
             credentials=(settings.GEONETWORK_USERNAME, settings.GEONETWORK_PASSWORD),
             gn_sync_mode=settings.GN_SYNC_MODE,

--- a/apps/backend/src/api/routes/ingestion/empty_dataset.py
+++ b/apps/backend/src/api/routes/ingestion/empty_dataset.py
@@ -47,7 +47,7 @@ def create_empty_dataset(
     session.refresh(integrity_link)
 
     try:
-        console_service = ConsoleService(settings.CONSOLE_URL)
+        console_service = ConsoleService(settings.CONSOLE_INTERNAL_URL)
         organization = console_service.get_organization(geo_ctx.organization)
 
         if organization:

--- a/apps/backend/src/api/routes/ingestion/integrity_link.py
+++ b/apps/backend/src/api/routes/ingestion/integrity_link.py
@@ -74,7 +74,7 @@ def _sync_metadata_sharing(
     )
 
     try:
-        console_service = ConsoleService(settings.CONSOLE_URL)
+        console_service = ConsoleService(settings.CONSOLE_INTERNAL_URL)
         if settings.GN_SYNC_MODE == "ORG":
             items = console_service.get_all_organizations()
             groups_by_id = {
@@ -162,7 +162,7 @@ def _sync_data_sharing(
     if uuids_to_resolve:
         # Only call Console when at least one non-EVERYONE role needs UUID resolution.
         # This keeps EVERYONE-only configs resilient to Console outages.
-        console_service = ConsoleService(settings.CONSOLE_URL)
+        console_service = ConsoleService(settings.CONSOLE_INTERNAL_URL)
         all_roles = console_service.get_all_roles()  # raises ConsoleServiceError on failure
         id_to_name = {
             str(r["id"]): f"ROLE_{r['name']}" for r in all_roles if r.get("id") and r.get("name")

--- a/apps/backend/src/api/routes/ingestion/integrity_link.py
+++ b/apps/backend/src/api/routes/ingestion/integrity_link.py
@@ -104,7 +104,7 @@ def _sync_metadata_sharing(
         resolved.append((gn_group_name, rule.rule_value))
 
     metadata_service = MetadataService(
-        gn_api_url=f"{settings.GEONETWORK_URL}/srv/api",
+        gn_api_url=f"{settings.GEONETWORK_INTERNAL_URL}/srv/api",
         datadir_path=settings.DATADIR_PATH,
         credentials=(settings.GEONETWORK_USERNAME, settings.GEONETWORK_PASSWORD),
         gn_sync_mode=settings.GN_SYNC_MODE,
@@ -266,7 +266,7 @@ def update_metadata_gn(
 
     settings = get_settings()
     metadata_service = MetadataService(
-        gn_api_url=f"{settings.GEONETWORK_URL}/srv/api",
+        gn_api_url=f"{settings.GEONETWORK_INTERNAL_URL}/srv/api",
         datadir_path=settings.DATADIR_PATH,
         credentials=(settings.GEONETWORK_USERNAME, settings.GEONETWORK_PASSWORD),
         verify_tls=False,
@@ -459,7 +459,7 @@ def toggle_publish_gn_integrity_link(
     # Create MetadataService instance
     settings = get_settings()
     metadata_service = MetadataService(
-        gn_api_url=f"{settings.GEONETWORK_URL}/srv/api",
+        gn_api_url=f"{settings.GEONETWORK_INTERNAL_URL}/srv/api",
         datadir_path=settings.DATADIR_PATH,
         credentials=(settings.GEONETWORK_USERNAME, settings.GEONETWORK_PASSWORD),
         verify_tls=False,
@@ -551,7 +551,7 @@ def delete_integrity_link(
         public_url=settings.DATA_PUBLIC_URL,
     )
     metadata_service = MetadataService(
-        gn_api_url=f"{settings.GEONETWORK_URL}/srv/api",
+        gn_api_url=f"{settings.GEONETWORK_INTERNAL_URL}/srv/api",
         datadir_path=settings.DATADIR_PATH,
         credentials=(settings.GEONETWORK_USERNAME, settings.GEONETWORK_PASSWORD),
         gn_sync_mode=settings.GN_SYNC_MODE,

--- a/apps/backend/src/api/routes/ingestion/integrity_link.py
+++ b/apps/backend/src/api/routes/ingestion/integrity_link.py
@@ -184,7 +184,7 @@ def _sync_data_sharing(
 
     if geoserver_service is None:
         geoserver_service = GeoServerService(
-            base_url=settings.GEOSERVER_URL,
+            base_url=settings.GEOSERVER_INTERNAL_URL,
             username=settings.GEOSERVER_USER,
             password=settings.GEOSERVER_PASSWORD,
             public_url=settings.DATA_PUBLIC_URL,
@@ -232,7 +232,7 @@ def _sync_title_geoserver(title: str, integrity_link: IntegrityLink) -> None:
         return
     settings = get_settings()
     gs = GeoServerService(
-        base_url=settings.GEOSERVER_URL,
+        base_url=settings.GEOSERVER_INTERNAL_URL,
         username=settings.GEOSERVER_USER,
         password=settings.GEOSERVER_PASSWORD,
         public_url=settings.DATA_PUBLIC_URL,
@@ -545,7 +545,7 @@ def delete_integrity_link(
 
     settings = get_settings()
     geoserver_service = GeoServerService(
-        base_url=settings.GEOSERVER_URL,
+        base_url=settings.GEOSERVER_INTERNAL_URL,
         username=settings.GEOSERVER_USER,
         password=settings.GEOSERVER_PASSWORD,
         public_url=settings.DATA_PUBLIC_URL,

--- a/apps/backend/src/api/routes/ingestion/integrity_links.py
+++ b/apps/backend/src/api/routes/ingestion/integrity_links.py
@@ -223,7 +223,9 @@ def list_integrity_links(
         item.has_integrity_rules = UUID(item.id) in rules_with_links
 
     usernames = list({item.integrity_owner for item in items})
-    display_names = ConsoleService(get_settings().CONSOLE_INTERNAL_URL).fetch_users_by_usernames(usernames)
+    display_names = ConsoleService(get_settings().CONSOLE_INTERNAL_URL).fetch_users_by_usernames(
+        usernames
+    )
     for item in items:
         item.owner_display_name = display_names.get(item.integrity_owner)
 

--- a/apps/backend/src/api/routes/ingestion/integrity_links.py
+++ b/apps/backend/src/api/routes/ingestion/integrity_links.py
@@ -223,7 +223,7 @@ def list_integrity_links(
         item.has_integrity_rules = UUID(item.id) in rules_with_links
 
     usernames = list({item.integrity_owner for item in items})
-    display_names = ConsoleService(get_settings().CONSOLE_URL).fetch_users_by_usernames(usernames)
+    display_names = ConsoleService(get_settings().CONSOLE_INTERNAL_URL).fetch_users_by_usernames(usernames)
     for item in items:
         item.owner_display_name = display_names.get(item.integrity_owner)
 

--- a/apps/backend/src/api/routes/ingestion/process.py
+++ b/apps/backend/src/api/routes/ingestion/process.py
@@ -214,7 +214,7 @@ def process_staging_data(
                 logger.info("Organization not found, using user info for metadata contact")
 
             metadata_service = MetadataService(
-                gn_api_url=f"{settings.GEONETWORK_URL}/srv/api",
+                gn_api_url=f"{settings.GEONETWORK_INTERNAL_URL}/srv/api",
                 datadir_path=settings.DATADIR_PATH,
                 credentials=(settings.GEONETWORK_USERNAME, settings.GEONETWORK_PASSWORD),
                 gn_sync_mode=settings.GN_SYNC_MODE,
@@ -418,7 +418,7 @@ async def dag_success_callback(
     if integrity_link.metadata_id is not None:
         try:
             metadata_service = MetadataService(
-                gn_api_url=f"{settings.GEONETWORK_URL}/srv/api",
+                gn_api_url=f"{settings.GEONETWORK_INTERNAL_URL}/srv/api",
                 datadir_path=settings.DATADIR_PATH,
                 credentials=(settings.GEONETWORK_USERNAME, settings.GEONETWORK_PASSWORD),
                 verify_tls=False,

--- a/apps/backend/src/api/routes/ingestion/process.py
+++ b/apps/backend/src/api/routes/ingestion/process.py
@@ -378,7 +378,7 @@ async def dag_success_callback(
                     mime_type="text/xml",
                 ),
                 MetadataLink(
-                    url=settings.CATALOGUE_URL.format(metadata_id=integrity_link.metadata_id),
+                    url=settings.DATAHUB_PUBLIC_URL.format(metadata_id=integrity_link.metadata_id),
                     metadata_type="ISO19115:2003",
                     mime_type="text/html",
                 ),

--- a/apps/backend/src/api/routes/ingestion/process.py
+++ b/apps/backend/src/api/routes/ingestion/process.py
@@ -195,7 +195,7 @@ def process_staging_data(
                 is_geographic=is_geographic,
             )
 
-            console_service = ConsoleService(settings.CONSOLE_URL)
+            console_service = ConsoleService(settings.CONSOLE_INTERNAL_URL)
             organization = console_service.get_organization(integrity_link.integrity_organization)
 
             user_first_name = sec_firstname

--- a/apps/backend/src/api/routes/metadata_groups.py
+++ b/apps/backend/src/api/routes/metadata_groups.py
@@ -22,7 +22,7 @@ router = APIRouter(prefix="/metadata/groups", tags=["Metadata"])
 )
 def list_groups(geo_ctx: GeorchestraContextDep) -> list[GroupItem]:
     settings = get_settings()
-    console_service = ConsoleService(settings.CONSOLE_URL)
+    console_service = ConsoleService(settings.CONSOLE_INTERNAL_URL)
 
     try:
         if settings.GN_SYNC_MODE == "ORG":

--- a/apps/backend/src/core/callback.py
+++ b/apps/backend/src/core/callback.py
@@ -15,7 +15,7 @@ def build_callback_url(route: str, query_params: dict[str, str] | None = None) -
     Returns:
         Full URL for the callback endpoint with query parameters
     """
-    base_url = f"{settings.BACKEND_URL}{route}"
+    base_url = f"{settings.BACKEND_INTERNAL_URL}{route}"
 
     if query_params:
         query_string = urlencode(query_params)

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -90,6 +90,8 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Datafeeder"
     BACKEND_INTERNAL_URL: str = "http://localhost:8000"
     DATA_PUBLIC_URL: str = "http://localhost:8080/geoserver"
+    DATAHUB_PUBLIC_URL: str = "http://localhost:8080/datahub/dataset/{metadata_id}"
+    METADATA_PUBLIC_URL: str = "http://localhost:8080/geonetwork"
     DATADIR_PATH: str = get_default_datadir()
 
     # API Configuration
@@ -162,9 +164,6 @@ class Settings(BaseSettings):
     GEOSERVER_USER: str = "testadmin"
 
     GEOSERVER_PASSWORD: str = "testadmin"
-
-    # Catalogue
-    DATAHUB_PUBLIC_URL: str = "http://localhost:8080/datahub/dataset/{metadata_id}"
 
     # Geonetwork
     GEONETWORK_INTERNAL_URL: str = "http://localhost:8080/geonetwork"
@@ -244,7 +243,7 @@ class Settings(BaseSettings):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def GEONETWORK_XML_RECORD_URL(self) -> str:
-        return f"{self.GEONETWORK_INTERNAL_URL}/srv/api/records/{{metadata_id}}/formatters/xml"
+        return f"{self.METADATA_PUBLIC_URL}/srv/api/records/{{metadata_id}}/formatters/xml"
 
     @model_validator(mode="after")
     def _set_default_emails_from(self) -> Self:

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -115,7 +115,7 @@ class Settings(BaseSettings):
     TASK_EXECUTOR: TaskExecutorType = TaskExecutorType.AIRFLOW
 
     # Airflow configuration
-    AIRFLOW_URL: str = "http://localhost:8081/airflow"
+    AIRFLOW_INTERNAL_URL: str = "http://localhost:8081/airflow"
     AIRFLOW_USERNAME: str = "airflow"
     AIRFLOW_PASSWORD: str = "airflow"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8  # 60 minutes * 24 hours * 8 days = 8 days

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -176,10 +176,8 @@ class Settings(BaseSettings):
     )
 
     # Geonetwork
-    GEONETWORK_URL: str = Field(
-        default="http://localhost:8080/geonetwork",
-        validation_alias=AliasChoices("geonetworkUrl", "GEONETWORK_URL"),
-    )
+    GEONETWORK_INTERNAL_URL: str = "http://localhost:8080/geonetwork"
+
     GEONETWORK_USERNAME: str = Field(
         default="testadmin", validation_alias=AliasChoices("geonetworkUser", "GEONETWORK_USERNAME")
     )
@@ -262,7 +260,7 @@ class Settings(BaseSettings):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def GEONETWORK_XML_RECORD_URL(self) -> str:
-        return f"{self.GEONETWORK_URL}/srv/api/records/{{metadata_id}}/formatters/xml"
+        return f"{self.GEONETWORK_INTERNAL_URL}/srv/api/records/{{metadata_id}}/formatters/xml"
 
     @model_validator(mode="after")
     def _set_default_emails_from(self) -> Self:

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -88,7 +88,7 @@ class Settings(BaseSettings):
 
     # Project Information
     PROJECT_NAME: str = "Datafeeder"
-    BACKEND_URL: str = "http://localhost:8000"
+    BACKEND_INTERNAL_URL: str = "http://localhost:8000"
     DATA_PUBLIC_URL: str = "http://localhost:8080/geoserver"
     DATADIR_PATH: str = get_default_datadir()
 
@@ -157,9 +157,9 @@ class Settings(BaseSettings):
     USE_ORG_SCHEMA: bool = False
 
     # GeoServer
-    GEOSERVER_URL: str = Field(
+    GEOSERVER_INTERNAL_URL: str = Field(
         default="http://localhost:8080/geoserver",
-        validation_alias=AliasChoices("geoserverUrl", "GEOSERVER_URL"),
+        validation_alias=AliasChoices("geoserverUrl", "GEOSERVER_INTERNAL_URL"),
     )
     GEOSERVER_USER: str = Field(
         default="testadmin", validation_alias=AliasChoices("geoserverUser", "GEOSERVER_USER")

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -157,44 +157,28 @@ class Settings(BaseSettings):
     USE_ORG_SCHEMA: bool = False
 
     # GeoServer
-    GEOSERVER_INTERNAL_URL: str = Field(
-        default="http://localhost:8080/geoserver",
-        validation_alias=AliasChoices("geoserverUrl", "GEOSERVER_INTERNAL_URL"),
-    )
-    GEOSERVER_USER: str = Field(
-        default="testadmin", validation_alias=AliasChoices("geoserverUser", "GEOSERVER_USER")
-    )
-    GEOSERVER_PASSWORD: str = Field(
-        default="testadmin",
-        validation_alias=AliasChoices("geoserverPassword", "GEOSERVER_PASSWORD"),
-    )
+    GEOSERVER_INTERNAL_URL: str = "http://localhost:8080/geoserver"
+
+    GEOSERVER_USER: str = "testadmin"
+
+    GEOSERVER_PASSWORD: str = "testadmin"
 
     # Catalogue
-    CATALOGUE_URL: str = Field(
-        default="http://localhost:8080/datahub/dataset/{metadata_id}",
-        validation_alias=AliasChoices("catalogueUrl", "CATALOGUE_URL"),
-    )
+    CATALOGUE_URL: str = "http://localhost:8080/datahub/dataset/{metadata_id}"
 
     # Geonetwork
     GEONETWORK_INTERNAL_URL: str = "http://localhost:8080/geonetwork"
 
-    GEONETWORK_USERNAME: str = Field(
-        default="testadmin", validation_alias=AliasChoices("geonetworkUser", "GEONETWORK_USERNAME")
-    )
-    GEONETWORK_PASSWORD: str = Field(
-        default="testadmin",
-        validation_alias=AliasChoices("geonetworkPassword", "GEONETWORK_PASSWORD"),
-    )
+    GEONETWORK_USERNAME: str = "testadmin"
+
+    GEONETWORK_PASSWORD: str = "testadmin"
+
     # This is odd, apparently any UUID works as XSRF token
     GEONETWORK_XSRF_TOKEN: str = "c9f33266-e242-4198-a18c-b01290dce5f1"
-    GN_SYNC_MODE: Literal["ORG", "ROLE"] = Field(
-        default="ORG",
-        validation_alias=AliasChoices("gnSyncMode", "GN_SYNC_MODE"),
-    )
-    METADATA_DEFAULT_GROUP_NAME: str = Field(
-        default="sample",
-        validation_alias=AliasChoices("metadataDefaultGroupName", "METADATA_DEFAULT_GROUP_NAME"),
-    )
+
+    GN_SYNC_MODE: Literal["ORG", "ROLE"] = "ORG"
+
+    METADATA_DEFAULT_GROUP_NAME: str = "sample"
 
     # Console
     CONSOLE_INTERNAL_URL: str = "CONSOLE_INTERNAL_URL"

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -180,7 +180,7 @@ class Settings(BaseSettings):
     METADATA_DEFAULT_GROUP_NAME: str = "sample"
 
     # Console
-    CONSOLE_INTERNAL_URL: str = "CONSOLE_INTERNAL_URL"
+    CONSOLE_INTERNAL_URL: str = "http://localhost:8085/console"
 
     # Metadata groups (for authorization UI)
     METADATA_GROUPS_LABEL_FILTER_REGEX: str = ""

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -199,10 +199,7 @@ class Settings(BaseSettings):
     )
 
     # Console
-    CONSOLE_URL: str = Field(
-        default="http://localhost:8085/console",
-        validation_alias=AliasChoices("consoleUrl", "CONSOLE_URL"),
-    )
+    CONSOLE_INTERNAL_URL: str = "CONSOLE_INTERNAL_URL"
 
     # Metadata groups (for authorization UI)
     METADATA_GROUPS_LABEL_FILTER_REGEX: str = ""

--- a/apps/backend/src/core/config.py
+++ b/apps/backend/src/core/config.py
@@ -164,7 +164,7 @@ class Settings(BaseSettings):
     GEOSERVER_PASSWORD: str = "testadmin"
 
     # Catalogue
-    CATALOGUE_URL: str = "http://localhost:8080/datahub/dataset/{metadata_id}"
+    DATAHUB_PUBLIC_URL: str = "http://localhost:8080/datahub/dataset/{metadata_id}"
 
     # Geonetwork
     GEONETWORK_INTERNAL_URL: str = "http://localhost:8080/geonetwork"

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -60,7 +60,7 @@ def read_version():
 @app.get("/geonetwork", tags=["Health"])
 def read_geonetwork():
     gnapi: GnApi = GnApi(
-        api_url=f"{get_settings().GEONETWORK_URL}srv/api",
+        api_url=f"{get_settings().GEONETWORK_INTERNAL_URL}srv/api",
         credentials=None,
         verifytls=False,
     )

--- a/apps/backend/src/services/airflow_client.py
+++ b/apps/backend/src/services/airflow_client.py
@@ -33,7 +33,7 @@ class AirflowAccessTokenResponse(BaseModel):
 def _request_new_access_token() -> str:
     settings = get_settings()
 
-    url = f"{settings.AIRFLOW_URL}/auth/token"
+    url = f"{settings.AIRFLOW_INTERNAL_URL}/auth/token"
     payload = {
         "username": settings.AIRFLOW_USERNAME,
         "password": settings.AIRFLOW_PASSWORD,
@@ -62,7 +62,7 @@ def _is_jwt_expired(token: str) -> bool:
 @lru_cache
 def _get_cached_airflow_api_client() -> ApiClient:
     settings = get_settings()
-    config = Configuration(host=settings.AIRFLOW_URL)
+    config = Configuration(host=settings.AIRFLOW_INTERNAL_URL)
     config.access_token = _request_new_access_token()
     return ApiClient(configuration=config)
 

--- a/apps/backend/src/services/files.py
+++ b/apps/backend/src/services/files.py
@@ -88,7 +88,7 @@ def get_temp_file_dir_path() -> str:
         The temporary upload directory path
     """
     settings = get_settings()
-    temp_file_folder = settings.BACKEND_URL + "/internal/files/"
+    temp_file_folder = settings.BACKEND_INTERNAL_URL + "/internal/files/"
 
     return temp_file_folder
 

--- a/apps/backend/src/services/settings_service.py
+++ b/apps/backend/src/services/settings_service.py
@@ -41,7 +41,7 @@ class SettingsService:
         settings_dict: dict[str, Any] = {
             "projections": projections,
             "enabled_features": enabled_features,
-            "catalogue_url": self._settings.CATALOGUE_URL,
+            "catalogue_url": self._settings.DATAHUB_PUBLIC_URL,
         }
         return settings_dict
 

--- a/apps/backend/tests/api/routes/test_data_groups.py
+++ b/apps/backend/tests/api/routes/test_data_groups.py
@@ -12,7 +12,7 @@ class TestDataGroups:
 
     def _mock_settings(self, filter_regex: str = "") -> MagicMock:
         mock_settings = MagicMock()
-        mock_settings.CONSOLE_URL = "http://console.example.com"
+        mock_settings.CONSOLE_INTERNAL_URL = "http://console.example.com"
         mock_settings.DATA_GROUPS_LABEL_FILTER_REGEX = filter_regex
         return mock_settings
 

--- a/apps/backend/tests/api/routes/test_empty_dataset.py
+++ b/apps/backend/tests/api/routes/test_empty_dataset.py
@@ -34,7 +34,7 @@ def _geo_ctx(
 def _mock_settings() -> MagicMock:
     settings = MagicMock()
     settings.CONSOLE_INTERNAL_URL = "http://console"
-    settings.GEONETWORK_URL = "http://geonetwork"
+    settings.GEONETWORK_INTERNAL_URL = "http://geonetwork"
     settings.GEONETWORK_USERNAME = "admin"
     settings.GEONETWORK_PASSWORD = "geonetwork"
     settings.DATADIR_PATH = "/datadir"

--- a/apps/backend/tests/api/routes/test_empty_dataset.py
+++ b/apps/backend/tests/api/routes/test_empty_dataset.py
@@ -33,7 +33,7 @@ def _geo_ctx(
 
 def _mock_settings() -> MagicMock:
     settings = MagicMock()
-    settings.CONSOLE_URL = "http://console"
+    settings.CONSOLE_INTERNAL_URL = "http://console"
     settings.GEONETWORK_URL = "http://geonetwork"
     settings.GEONETWORK_USERNAME = "admin"
     settings.GEONETWORK_PASSWORD = "geonetwork"

--- a/apps/backend/tests/api/routes/test_geonetwork.py
+++ b/apps/backend/tests/api/routes/test_geonetwork.py
@@ -14,7 +14,7 @@ class TestGeoNetworkProxy:
     def mock_settings(self) -> Mock:
         """Create mock settings for GeoNetwork connection."""
         settings = Mock()
-        settings.GEONETWORK_URL = "http://geonetwork.example.com/geonetwork"
+        settings.GEONETWORK_INTERNAL_URL = "http://geonetwork.example.com/geonetwork"
         settings.GEONETWORK_USERNAME = "test_user"
         settings.GEONETWORK_PASSWORD = "test_pass"
         return settings
@@ -60,7 +60,7 @@ class TestGeoNetworkProxy:
                 # Verify correct URL with query string
                 call_kwargs = mock_client.request.call_args.kwargs
                 assert call_kwargs["method"] == "GET"
-                expected_url = f"{mock_settings.GEONETWORK_URL}/{path}?{query}"
+                expected_url = f"{mock_settings.GEONETWORK_INTERNAL_URL}/{path}?{query}"
                 assert call_kwargs["url"] == expected_url
 
                 # Verify response
@@ -238,6 +238,6 @@ class TestGeoNetworkProxy:
 
                 # Verify URL has no query string
                 call_kwargs = mock_client.request.call_args.kwargs
-                expected_url = f"{mock_settings.GEONETWORK_URL}/{path}"
+                expected_url = f"{mock_settings.GEONETWORK_INTERNAL_URL}/{path}"
                 assert call_kwargs["url"] == expected_url
                 assert "?" not in call_kwargs["url"]

--- a/apps/backend/tests/api/routes/test_integrity_link.py
+++ b/apps/backend/tests/api/routes/test_integrity_link.py
@@ -1922,7 +1922,7 @@ class TestUpdateMetadataGn:
 
     def _mock_settings(self) -> MagicMock:
         s = MagicMock()
-        s.GEONETWORK_URL = "http://geonetwork"
+        s.GEONETWORK_INTERNAL_URL = "http://geonetwork"
         s.DATADIR_PATH = "/datadir"
         s.GEONETWORK_USERNAME = "admin"
         s.GEONETWORK_PASSWORD = "password"

--- a/apps/backend/tests/api/routes/test_integrity_link.py
+++ b/apps/backend/tests/api/routes/test_integrity_link.py
@@ -2107,7 +2107,7 @@ class TestSyncTitleGeoserver:
 
     def _mock_settings(self) -> MagicMock:
         s = MagicMock()
-        s.GEOSERVER_URL = "http://geoserver"
+        s.GEOSERVER_INTERNAL_URL = "http://geoserver"
         s.GEOSERVER_USER = "admin"
         s.GEOSERVER_PASSWORD = "password"
         s.DATA_PUBLIC_URL = "http://public"

--- a/apps/backend/tests/api/routes/test_metadata_groups.py
+++ b/apps/backend/tests/api/routes/test_metadata_groups.py
@@ -12,7 +12,7 @@ class TestMetadataGroups:
 
     def _mock_settings(self, gn_sync_mode: str = "ORG", filter_regex: str = "") -> MagicMock:
         mock_settings = MagicMock()
-        mock_settings.CONSOLE_URL = "http://console.example.com"
+        mock_settings.CONSOLE_INTERNAL_URL = "http://console.example.com"
         mock_settings.GN_SYNC_MODE = gn_sync_mode
         mock_settings.METADATA_GROUPS_LABEL_FILTER_REGEX = filter_regex
         return mock_settings

--- a/apps/backend/tests/services/test_airflow_client.py
+++ b/apps/backend/tests/services/test_airflow_client.py
@@ -34,7 +34,7 @@ class TestAirflowClient:
     def mock_settings(self) -> Mock:
         """Create mock settings for Airflow connection."""
         settings = Mock()
-        settings.AIRFLOW_URL = "http://test-airflow.example.com"
+        settings.AIRFLOW_INTERNAL_URL = "http://test-airflow.example.com"
         settings.AIRFLOW_USERNAME = "test_user"
         settings.AIRFLOW_PASSWORD = "test_pass"
         return settings

--- a/apps/backend/tests/services/test_files.py
+++ b/apps/backend/tests/services/test_files.py
@@ -58,7 +58,7 @@ class TestUploadFileToTemp:
         """Create mock settings."""
         settings = MagicMock()
         settings.TMP_UPLOAD_PATH = "/tmp"
-        settings.BACKEND_URL = "http://localhost:8000"
+        settings.BACKEND_INTERNAL_URL = "http://localhost:8000"
         return settings
 
     @pytest.fixture
@@ -294,7 +294,7 @@ class TestGetTempFileUrl:
     def mock_settings(self) -> MagicMock:
         """Create mock settings."""
         settings = MagicMock()
-        settings.BACKEND_URL = "http://localhost:8000"
+        settings.BACKEND_INTERNAL_URL = "http://localhost:8000"
         return settings
 
     @patch("src.services.files.get_settings")
@@ -313,7 +313,7 @@ class TestGetTempFileUrl:
     def test_get_temp_file_url_different_backend(self, mock_get_settings: MagicMock) -> None:
         """Test generating URL with different backend URL."""
         settings = MagicMock()
-        settings.BACKEND_URL = "https://example.com/api"
+        settings.BACKEND_INTERNAL_URL = "https://example.com/api"
         mock_get_settings.return_value = settings
         filename = "data.csv"
 
@@ -343,7 +343,7 @@ class TestDeleteTempFile:
         """Create mock settings."""
         settings = MagicMock()
         settings.TMP_UPLOAD_PATH = "/tmp"
-        settings.BACKEND_URL = "http://localhost:8000"
+        settings.BACKEND_INTERNAL_URL = "http://localhost:8000"
         return settings
 
     @patch("src.services.files.get_settings")

--- a/apps/elt/dags/process-dag-generator.py
+++ b/apps/elt/dags/process-dag-generator.py
@@ -30,7 +30,7 @@ def load_scheduled_integrity_links():
 
 
 def _build_callback_url(route: str, integrity_link_id: str, final_table_name: str) -> str:
-    backend_url = os.environ.get("BACKEND_URL", "http://datafeeder-backend:8000")
+    backend_url = os.environ.get("BACKEND_INTERNAL_URL", "http://datafeeder-backend:8000")
     params = urlencode(
         {"integrity_link_id": integrity_link_id, "final_table_name": final_table_name}
     )

--- a/apps/elt/dags/tests/test_process_dag_generator.py
+++ b/apps/elt/dags/tests/test_process_dag_generator.py
@@ -55,7 +55,7 @@ _build_callback_url = _load_build_callback_url()
 
 class TestBuildCallbackUrl:
     def test_success_url_uses_backend_url_env(self, monkeypatch):
-        monkeypatch.setenv("BACKEND_URL", "http://my-backend:9000")
+        monkeypatch.setenv("BACKEND_INTERNAL_URL", "http://my-backend:9000")
         url = _build_callback_url("/ingestion/process/dag_success", "abc-123", "my_table")
         parsed = urlparse(url)
         assert parsed.scheme == "http"
@@ -63,23 +63,23 @@ class TestBuildCallbackUrl:
         assert parsed.path == "/ingestion/process/dag_success"
 
     def test_success_url_contains_integrity_link_id(self, monkeypatch):
-        monkeypatch.setenv("BACKEND_URL", "http://datafeeder-backend:8000")
+        monkeypatch.setenv("BACKEND_INTERNAL_URL", "http://datafeeder-backend:8000")
         url = _build_callback_url("/ingestion/process/dag_success", "abc-123", "my_table")
         qs = parse_qs(urlparse(url).query)
         assert qs["integrity_link_id"] == ["abc-123"]
 
     def test_success_url_contains_final_table_name(self, monkeypatch):
-        monkeypatch.setenv("BACKEND_URL", "http://datafeeder-backend:8000")
+        monkeypatch.setenv("BACKEND_INTERNAL_URL", "http://datafeeder-backend:8000")
         url = _build_callback_url("/ingestion/process/dag_success", "abc-123", "my_table")
         qs = parse_qs(urlparse(url).query)
         assert qs["final_table_name"] == ["my_table"]
 
     def test_failure_url_points_to_dag_failure_endpoint(self, monkeypatch):
-        monkeypatch.setenv("BACKEND_URL", "http://datafeeder-backend:8000")
+        monkeypatch.setenv("BACKEND_INTERNAL_URL", "http://datafeeder-backend:8000")
         url = _build_callback_url("/ingestion/process/dag_failure", "abc-123", "my_table")
         assert urlparse(url).path == "/ingestion/process/dag_failure"
 
     def test_default_backend_url_when_env_not_set(self, monkeypatch):
-        monkeypatch.delenv("BACKEND_URL", raising=False)
+        monkeypatch.delenv("BACKEND_INTERNAL_URL", raising=False)
         url = _build_callback_url("/ingestion/process/dag_success", "abc-123", "my_table")
         assert url.startswith("http://datafeeder-backend:8000")

--- a/apps/frontend/scripts/generate-api.sh
+++ b/apps/frontend/scripts/generate-api.sh
@@ -2,20 +2,20 @@
 set -euo pipefail
 
 APPS_DIR="apps"
-BACKEND_URL="http://localhost:8000"
+BACKEND_INTERNAL_URL="http://localhost:8000"
 FRONTEND_DIR="frontend"
 OPENAPI_FILE="openapi.json"
 
 # Check if backend is running
-if ! curl -s "$BACKEND_URL/openapi.json" > /dev/null; then
-    echo "Error: Backend is not running at $BACKEND_URL"
+if ! curl -s "$BACKEND_INTERNAL_URL/openapi.json" > /dev/null; then
+    echo "Error: Backend is not running at $BACKEND_INTERNAL_URL"
     echo "Please start the backend first with: make run-backend"
     exit 1
 fi
 
 # Download OpenAPI spec from running backend
 echo "Downloading OpenAPI spec from backend..."
-curl -s "$BACKEND_URL/openapi.json" > "$APPS_DIR/$FRONTEND_DIR/$OPENAPI_FILE"
+curl -s "$BACKEND_INTERNAL_URL/openapi.json" > "$APPS_DIR/$FRONTEND_DIR/$OPENAPI_FILE"
 
 # Generate the API client
 echo "Generating API client..."

--- a/docker/.envs-common
+++ b/docker/.envs-common
@@ -9,6 +9,6 @@ FRONTEND_HOST=http://localhost:5173
 BACKEND_HOST=http://datafeeder-backend:8000
 
 # GeoServer configuration
-GEOSERVER_URL=http://localhost:8080/geoserver
+GEOSERVER_INTERNAL_URL=http://localhost:8080/geoserver
 GEOSERVER_USER=testadmin
 GEOSERVER_PASSWORD=testadmin

--- a/docker/.envs-hosts
+++ b/docker/.envs-hosts
@@ -19,6 +19,6 @@ DATA_API_HOST=data-api
 AIRFLOW_HOST=airflow-apiserver
 
 # needed for geonetwork entrypoint DO NOT REMOVE
-CONSOLE_URL=http://${CONSOLE_HOST}:8080
+CONSOLE_INTERNAL_URL=http://${CONSOLE_HOST}:8080
 # needed for kibana DO NOT REMOVE
 ELASTICSEARCH_HOSTS=http://${ES_HOST}:${ES_PORT}

--- a/docker/compose.airflow.yaml
+++ b/docker/compose.airflow.yaml
@@ -88,7 +88,7 @@ x-airflow-common:
     # The following line can be used to set a custom config file, stored in the local config folder
     AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'
     AIRFLOW__API_AUTH__JWT_SECRET: 'nty6o8yV+OsnfEvsZ/ehZQ=='
-    BACKEND_URL: ${BACKEND_URL:-http://host.docker.internal:8000}
+    BACKEND_INTERNAL_URL: ${BACKEND_INTERNAL_URL:-http://host.docker.internal:8000}
   volumes:
     - ../apps/elt/dags:/opt/airflow/dags
     - ../libs/data_manipulation/src/data_manipulation:/opt/airflow/dags/data_manipulation

--- a/docker/datadir/datafeeder-python/datafeeder.env
+++ b/docker/datadir/datafeeder-python/datafeeder.env
@@ -1,6 +1,6 @@
 # Used to override default values in config.py
 BACKEND_INTERNAL_URL=http://datafeeder-backend:8000
-AIRFLOW_URL=http://${AIRFLOW_HOST}:8081/airflow
+AIRFLOW_INTERNAL_URL=http://${AIRFLOW_HOST}:8081/airflow
 ENCRYPTION_KEY=your_encryption_key
 POSTGRES_DATA_HOST=datadb
 POSTGRES_DATA_PORT=5432

--- a/docker/datadir/datafeeder-python/datafeeder.env
+++ b/docker/datadir/datafeeder-python/datafeeder.env
@@ -1,5 +1,5 @@
 # Used to override default values in config.py
-BACKEND_URL=http://datafeeder-backend:8000
+BACKEND_INTERNAL_URL=http://datafeeder-backend:8000
 AIRFLOW_URL=http://${AIRFLOW_HOST}:8081/airflow
 ENCRYPTION_KEY=your_encryption_key
 POSTGRES_DATA_HOST=datadb

--- a/docker/datadir/default.properties
+++ b/docker/datadir/default.properties
@@ -171,7 +171,7 @@ analyticsEnabled=false
 
 # GeoServer base URL
 # URL to access GeoServer REST API
-geoserverUrl=${GEOSERVER_URL}
+geoserverUrl=${GEOSERVER_INTERNAL_URL}
 
 # GeoServer admin user
 # Username for GeoServer authentication


### PR DESCRIPTION
Rename:
- `BACKEND_URL` to `BACKEND_INTERNAL_URL`
- `GEOSERVER_URL` to `GEOSERVER_INTERNAL_URL`
- `GEONETWORK_URL` to `GEONETWORK_INTERNAL_URL`
- `AIRFLOW_URL` to `AIRFLOW_INTERNAL_URL`
- `CATALOGUE_URL` to `DATAHUB_PUBLIC_URL`

Remove AliasChoices for variables that aren't existing in geOrchestra's datadir.

Update Gn xml public URL 