### PR TITLE
fix(staging): serialize date columns in dataset preview

### DIFF
--- a/apps/backend/src/api/routes/ingestion/staging.py
+++ b/apps/backend/src/api/routes/ingestion/staging.py
@@ -1,6 +1,6 @@
 import json
 import re
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, Optional
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
@@ -774,6 +774,33 @@ def dag_failure_callback(
         datafeeder_session.commit()
 
 
+def _stringify_temporal_columns(df: pd.DataFrame) -> None:
+    """Stringify temporal columns in place so preview data is JSON-serializable.
+
+    Handles datetime64 columns and object-dtype columns holding Python
+    date/datetime objects (e.g. Parquet date32), which is_datetime64_any_dtype
+    does not detect. Geometry columns are left untouched.
+    """
+
+    # datetime is a subclass of date, so isinstance(v, date) matches both plain
+    # dates (Parquet date32) and full timestamps; isoformat() renders both cleanly.
+    def _iso(value: Any) -> Any:
+        return value.isoformat() if isinstance(value, date) else value
+
+    for col in df.columns:
+        series = df[col]
+        if pd.api.types.is_datetime64_any_dtype(series):
+            df[col] = series.astype(str)  # type: ignore[misc]
+        elif series.dtype == "object":
+            # Sample the first non-null value to decide the column's real type;
+            # an all-null column has nothing to serialize, so we skip it.
+            non_null = series.dropna()  # type: ignore[misc]
+            if not non_null.empty and isinstance(non_null.iloc[0], date):  # type: ignore[misc]
+                # Convert per-value (not astype) so any stray nulls survive as
+                # None instead of becoming the string "NaT"/"None".
+                df[col] = series.apply(_iso)  # type: ignore[misc]
+
+
 def _detect_original_projection(
     staging_table_name: str,
     engine: Any,
@@ -1113,16 +1140,8 @@ def get_staging_preview(
             staging_table_name, engine, schema, config, limit=limit
         )
 
-        # Convert all non-JSON-serializable types to string (datetime, Timestamp, etc.)
-        for col in transformed_data.columns:
-            if transformed_data[col].dtype == "object":
-                try:
-                    if pd.api.types.is_datetime64_any_dtype(transformed_data[col]):
-                        transformed_data[col] = transformed_data[col].astype(str)  # type: ignore[misc]
-                except Exception:
-                    pass
-            elif pd.api.types.is_datetime64_any_dtype(transformed_data[col]):
-                transformed_data[col] = transformed_data[col].astype(str)  # type: ignore[misc]
+        # Convert non-JSON-serializable temporal types to string (datetime, date, Timestamp).
+        _stringify_temporal_columns(transformed_data)
 
         data: list[dict[str, Any]] = []
         geojson_data = None

--- a/apps/backend/tests/api/routes/test_staging_api.py
+++ b/apps/backend/tests/api/routes/test_staging_api.py
@@ -1,14 +1,16 @@
 """Tests for API (OGC service) source type in staging endpoints."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import pandas as pd
 import pytest
 from fastapi import HTTPException
 
 from src.api.routes.ingestion.staging import (
     _process_import_source,  # pyright: ignore[reportPrivateUsage]
+    _stringify_temporal_columns,  # pyright: ignore[reportPrivateUsage]
     dag_failure_callback,
     dag_success_callback,
     edit_staging,
@@ -528,3 +530,46 @@ class TestDagFailureCallbackTempFile:
         datafeeder_session, _ = self._call(link)
 
         datafeeder_session.delete.assert_called_once_with(link)
+
+
+class TestStringifyTemporalColumns:
+    """Preview data must be JSON-serializable; temporal columns get stringified."""
+
+    def test_object_date_column_becomes_iso_strings(self) -> None:
+        df = pd.DataFrame({"d": [date(2024, 1, 2), date(2024, 3, 4)]})
+        assert df["d"].dtype == "object"
+
+        _stringify_temporal_columns(df)
+
+        assert df["d"].tolist() == ["2024-01-02", "2024-03-04"]
+
+    def test_object_datetime_column_becomes_iso_strings(self) -> None:
+        df = pd.DataFrame({"dt": [datetime(2024, 1, 2, 8, 30), datetime(2024, 3, 4, 9, 0)]})
+        df["dt"] = df["dt"].astype(object)
+
+        _stringify_temporal_columns(df)
+
+        assert df["dt"].tolist() == ["2024-01-02T08:30:00", "2024-03-04T09:00:00"]
+
+    def test_datetime64_column_becomes_strings(self) -> None:
+        df = pd.DataFrame({"ts": pd.to_datetime(["2024-01-02", "2024-03-04"])})
+        assert pd.api.types.is_datetime64_any_dtype(df["ts"])
+
+        _stringify_temporal_columns(df)
+
+        assert all(isinstance(v, str) for v in df["ts"])
+
+    def test_non_temporal_columns_are_left_intact(self) -> None:
+        df = pd.DataFrame({"name": ["a", "b"], "n": [1, 2]})
+
+        _stringify_temporal_columns(df)
+
+        assert df["name"].tolist() == ["a", "b"]
+        assert df["n"].tolist() == [1, 2]
+
+    def test_nulls_do_not_raise_and_are_preserved(self) -> None:
+        df = pd.DataFrame({"d": [None, date(2024, 1, 2)]})
+
+        _stringify_temporal_columns(df)
+
+        assert df["d"].tolist() == [None, "2024-01-02"]


### PR DESCRIPTION
## Bug

Loading a Parquet file in the **Configure the dataset** step of the funnel fails with a 500:

```
Error
Object of type date is not JSON serializable
```

Backend logs:

```
ERROR: Error applying transformations for preview: Object of type date is not JSON serializable
GET /ingestion/staging/<id>/preview?limit=10&raw=false&include_excluded=true 500 Internal Server Error
```

Reproduced with the Bourges Plus carpool dataset:
`https://data.bourgesplus.fr/api/v2/catalog/datasets/lieuxcovoiturage/exports/parquet`

<img width="1668" height="1004" alt="image (7)" src="https://github.com/user-attachments/assets/79c83c78-db34-4f98-bcfe-0860b12d72c5" />

## Context

This is a bug in the backend, not a problem with the file — `date`-typed columns are valid.

Parquet `date32` columns load into pandas as **object-dtype columns of Python `datetime.date`
objects**, not `datetime64`. The serialization-safety loop in the staging preview endpoint
(`apps/backend/src/api/routes/ingestion/staging.py`) only stringified `datetime64` columns:

```python
if pd.api.types.is_datetime64_any_dtype(transformed_data[col]):
    transformed_data[col] = transformed_data[col].astype(str)
```

`is_datetime64_any_dtype` returns `False` for object columns holding `datetime.date`, so the
column was never converted (the object-dtype branch was effectively dead — that inner check
is never true for object dtype). It then reached `map_gdf.to_json()` (geopandas serializing
feature properties with the stdlib JSON encoder) and pydantic serialization of the `data`
list, both of which raise on `datetime.date`.

## Fix

Replace the convoluted loop with a small, testable helper `_stringify_temporal_columns(df)`
that stringifies:

- `datetime64` columns (`.astype(str)`, as before), and
- object-dtype columns holding `datetime.date` / `datetime.datetime` values (`.isoformat()`).

`datetime` subclasses `date`, so a single `isinstance(v, date)` check covers both. Geometry
columns (object-dtype `BaseGeometry`) are left untouched, so the existing geometry/GeoJSON
handling below is unaffected. The helper mutates `transformed_data` in place **before** the
`map_gdf` copy is taken, so it fixes both the tabular `data` and the map GeoJSON output.

### Notes

Bug found and fixed with Claude code cli (with Opus 4.8)