### PR TITLE
feat: chunk read write to contain memory usage 

### DIFF
--- a/apps/elt/dags/task_groups/transformation.py
+++ b/apps/elt/dags/task_groups/transformation.py
@@ -7,6 +7,7 @@ from airflow.exceptions import AirflowException
 from airflow.sdk import task, task_group
 from airflow.utils.trigger_rule import TriggerRule
 from data_manipulation import (
+    CHUNK_SIZE,
     IntegrityTransformation,
     read_and_transform_data,
     write_data_to_postgis,
@@ -85,22 +86,6 @@ def process_transformation_group(
             staging_schema = get_staging_schema()
 
             try:
-                logger.info(
-                    f"Reading and transforming data from {staging_schema}.{staging_table_name}"
-                )
-                transformed_data = read_and_transform_data(
-                    table_name=staging_table_name,
-                    engine=engine,
-                    schema=staging_schema,
-                    config=transformation_config,
-                    limit=None,
-                )
-                logger.info(f"Transformations applied to {len(transformed_data)} rows")
-
-                if transformed_data.empty:
-                    logger.error("No data to write after transformation.")
-                    raise AirflowException("No data to write after transformation.")
-
                 # If this is a re-run (has last_retrieval_timestamp), drop the old final table first
                 last_retrieval_timestamp = params.get("last_retrieval_timestamp")
                 if last_retrieval_timestamp:
@@ -124,15 +109,54 @@ def process_transformation_group(
                         )
 
                 create_schema(engine, final_schema)
-                logger.info(f"Writing data to {final_schema}.{final_table_name}")
-                write_data_to_postgis(
-                    data=transformed_data,
-                    table_name=final_table_name,
-                    engine=engine,
-                    schema=final_schema,
-                    create_id=True,
+
+                logger.info(
+                    f"Reading, transforming and writing data from "
+                    f"{staging_schema}.{staging_table_name} to {final_schema}.{final_table_name}"
                 )
-                logger.info(f"Successfully wrote {len(transformed_data)} rows to final table")
+
+                # Read, transform and write one chunk at a time to keep the memory footprint
+                # low for large tables (mirrors the chunked ingestion in ingestion.py).
+                i = 0
+                total_rows = 0
+                while True:
+                    transformed_data = read_and_transform_data(
+                        table_name=staging_table_name,
+                        engine=engine,
+                        schema=staging_schema,
+                        config=transformation_config,
+                        limit=CHUNK_SIZE,
+                        offset=i * CHUNK_SIZE,
+                    )
+                    if transformed_data.empty:
+                        break
+
+                    chunk_len = len(transformed_data)
+                    write_data_to_postgis(
+                        data=transformed_data,
+                        table_name=final_table_name,
+                        engine=engine,
+                        schema=final_schema,
+                        # The UUID primary key is created once on the first chunk; subsequent
+                        # appended rows receive their id_datafeeder from the column default.
+                        create_id=i == 0,
+                        if_exists="replace" if i == 0 else "append",
+                    )
+                    total_rows += chunk_len
+                    logger.info(
+                        f"Transformed and wrote chunk {i} ({chunk_len} rows) to final table"
+                    )
+
+                    # A short read means the staging table is exhausted — avoid an extra empty query.
+                    if chunk_len < CHUNK_SIZE:
+                        break
+                    i += 1
+
+                if total_rows == 0:
+                    logger.error("No data to write after transformation.")
+                    raise AirflowException("No data to write after transformation.")
+
+                logger.info(f"Successfully wrote {total_rows} rows to final table")
 
             except Exception as e:
                 raise AirflowException(f"Failed to transform and load data: {e}")

--- a/apps/elt/dags/tests/test_transformation_group.py
+++ b/apps/elt/dags/tests/test_transformation_group.py
@@ -5,6 +5,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 
 class _FakeTask:
     """Stand-in for a decorated Airflow task: records kwargs, supports >>."""
@@ -56,6 +58,7 @@ def _load_transformation_module():
     trigger_rule_stub.TriggerRule = _TriggerRule  # type: ignore[attr-defined]
 
     dm_stub = types.ModuleType("data_manipulation")
+    dm_stub.CHUNK_SIZE = 10000  # type: ignore[attr-defined]
     dm_stub.IntegrityTransformation = type("IntegrityTransformation", (), {})  # type: ignore[attr-defined]
     dm_stub.read_and_transform_data = lambda *a, **kw: None  # type: ignore[attr-defined]
     dm_stub.write_data_to_postgis = lambda *a, **kw: None  # type: ignore[attr-defined]
@@ -112,6 +115,88 @@ def _clean_task_kwargs(**factory_kwargs) -> dict:
     group = _transformation.process_transformation_group(**factory_kwargs)
     group()  # execute the group body so the @task decorators run
     return _TASK_REGISTRY["clean_staging_table_task"].kwargs
+
+
+def _build_read_task(**factory_kwargs) -> _FakeTask:
+    """Build the group and return its read_transform_write_task wrapper."""
+    _TASK_REGISTRY.clear()
+    group = _transformation.process_transformation_group(**factory_kwargs)
+    group()
+    return _TASK_REGISTRY["read_transform_write_task"]
+
+
+class TestReadTransformWriteChunking:
+    """The read/transform/write task streams the staging table in chunks."""
+
+    class _FakeFrame:
+        def __init__(self, n: int) -> None:
+            self._n = n
+
+        @property
+        def empty(self) -> bool:
+            return self._n == 0
+
+        def __len__(self) -> int:
+            return self._n
+
+    def _run_task(self, monkeypatch, chunk_lengths, chunk_size=2):
+        """Execute the task with read_and_transform_data yielding chunk_lengths."""
+        read_calls: list[dict] = []
+        write_calls: list[dict] = []
+
+        frames = [self._FakeFrame(n) for n in chunk_lengths]
+
+        def fake_read(**kwargs):
+            read_calls.append(kwargs)
+            return frames.pop(0) if frames else self._FakeFrame(0)
+
+        def fake_write(**kwargs):
+            write_calls.append(kwargs)
+
+        monkeypatch.setattr(_transformation, "CHUNK_SIZE", chunk_size)
+        monkeypatch.setattr(_transformation, "read_and_transform_data", fake_read)
+        monkeypatch.setattr(_transformation, "write_data_to_postgis", fake_write)
+        monkeypatch.setattr(_transformation, "create_schema", lambda *a, **kw: None)
+        monkeypatch.setattr(_transformation, "get_data_sql_engine", lambda: object())
+        monkeypatch.setattr(_transformation, "get_staging_schema", lambda: "staging")
+
+        task = _build_read_task(group_id="g")
+        context = {
+            "params": {
+                "final_table_name": "final_t",
+                "staging_table_name": "staging_t",
+                "integrity_transformation": {},
+            },
+            "ti": object(),
+        }
+        task.fn(**context)
+        return read_calls, write_calls
+
+    def test_streams_in_chunks_with_offsets(self, monkeypatch):
+        """Two full chunks then a short chunk: reads paginate by offset, writes append."""
+        read_calls, write_calls = self._run_task(monkeypatch, [2, 2, 1], chunk_size=2)
+
+        assert [c["offset"] for c in read_calls] == [0, 2, 4]
+        assert all(c["limit"] == 2 for c in read_calls)
+
+        assert len(write_calls) == 3
+        assert write_calls[0]["if_exists"] == "replace"
+        assert write_calls[0]["create_id"] is True
+        assert all(w["if_exists"] == "append" for w in write_calls[1:])
+        assert all(w["create_id"] is False for w in write_calls[1:])
+
+    def test_short_first_chunk_stops_after_one_read(self, monkeypatch):
+        """A first chunk smaller than CHUNK_SIZE ends the loop without an extra query."""
+        read_calls, write_calls = self._run_task(monkeypatch, [1], chunk_size=2)
+
+        assert len(read_calls) == 1
+        assert len(write_calls) == 1
+        assert write_calls[0]["if_exists"] == "replace"
+
+    def test_empty_staging_raises(self, monkeypatch):
+        """An empty staging table raises and never writes."""
+        with pytest.raises(Exception, match="Failed to transform and load data"):
+            self._run_task(monkeypatch, [0], chunk_size=2)
 
 
 class TestCleanStagingTableTriggerRule:

--- a/docker/compose.airflow.yaml
+++ b/docker/compose.airflow.yaml
@@ -89,6 +89,7 @@ x-airflow-common:
     AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'
     AIRFLOW__API_AUTH__JWT_SECRET: 'nty6o8yV+OsnfEvsZ/ehZQ=='
     BACKEND_INTERNAL_URL: ${BACKEND_INTERNAL_URL:-http://host.docker.internal:8000}
+    PYOGRIO_USE_ARROW: 1
   volumes:
     - ../apps/elt/dags:/opt/airflow/dags
     - ../libs/data_manipulation/src/data_manipulation:/opt/airflow/dags/data_manipulation

--- a/libs/data_manipulation/src/data_manipulation/__init__.py
+++ b/libs/data_manipulation/src/data_manipulation/__init__.py
@@ -1,4 +1,5 @@
 from data_manipulation.ingestion import (
+    CHUNK_SIZE,
     ingest_data_from_file_into_postgis,
     ingest_data_from_ogc_service_into_postgis,
     ingest_data_from_url_into_postgis,
@@ -21,6 +22,7 @@ from data_manipulation.type_detection import detect_column_type_from_sqla
 
 __all__ = [
     "hello",
+    "CHUNK_SIZE",
     "ingest_data_from_file_into_postgis",
     "ingest_data_from_ogc_service_into_postgis",
     "ingest_data_from_url_into_postgis",

--- a/libs/data_manipulation/src/data_manipulation/ingestion.py
+++ b/libs/data_manipulation/src/data_manipulation/ingestion.py
@@ -2,6 +2,7 @@ import logging
 import re
 import tempfile
 from pathlib import Path
+from typing import Literal
 from urllib.error import URLError
 from urllib.parse import quote, unquote, urlparse
 from urllib.request import urlretrieve
@@ -28,6 +29,9 @@ DEFAULT_SCHEMA = "public"
 # Bytes sampled for encoding detection. chardet's accuracy is unchanged for a sample
 # this size, and reading only a sample avoids loading multi-GB files into memory.
 _ENCODING_DETECT_BYTES = 256 * 1024
+# Number of rows read and written to PostGIS per chunk. Keeps the memory footprint low
+# (only one chunk is held in memory / converted to WKB at a time) for large files.
+CHUNK_SIZE = 50000
 
 
 def _get_table_row_count(table_name: str, engine: Engine, schema: str) -> int:
@@ -72,17 +76,26 @@ def _detect_file_encoding(file_path: str) -> str:
     return encoding or "utf-8"
 
 
-def _read_file_encoded(file_path: str) -> gpd.GeoDataFrame | pd.DataFrame:
-    """Read a geospatial file with the specified encoding.
+def _read_file_encoded(file_path: str, i: int = 0) -> gpd.GeoDataFrame | pd.DataFrame:
+    """Read a chunk of a geospatial file, handling encoding detection.
+
+    Reads ``CHUNK_SIZE`` rows starting at offset ``i * CHUNK_SIZE``. Returns an empty
+    frame once the offset is past the end of the file, which lets callers iterate until
+    the whole file has been ingested without ever loading it entirely in memory.
 
     Args:
         file_path: Path to the file
-        encoding: Encoding to use
+        i: Zero-based chunk index
 
     Returns:
-        GeoDataFrame or DataFrame with the file data
+        GeoDataFrame or DataFrame with the chunk data (empty when there is no more data)
     """
+    rows = slice(i * CHUNK_SIZE, i * CHUNK_SIZE + CHUNK_SIZE, None)
+    # Parquet is columnar and not row-sliceable cheaply: read it fully on the first
+    # chunk and signal completion afterwards to avoid re-reading / duplicating rows.
     if Path(file_path).suffix.lower() in (".parquet", ".geoparquet"):
+        if i > 0:
+            return gpd.GeoDataFrame()
         try:
             return gpd.read_parquet(file_path)  # type: ignore[arg-type]
         except ValueError:
@@ -90,8 +103,7 @@ def _read_file_encoded(file_path: str) -> gpd.GeoDataFrame | pd.DataFrame:
 
     try:
         # Try reading with UTF-8 first (common default)
-        data = gpd.read_file(file_path)  # type: ignore[arg-type]
-        return data
+        return gpd.read_file(file_path, rows=rows)  # type: ignore[arg-type]
     except UnicodeDecodeError:
         logger.warning(
             "Failed to read file with UTF-8 encoding, attempting to detect encoding and read again."
@@ -100,10 +112,7 @@ def _read_file_encoded(file_path: str) -> gpd.GeoDataFrame | pd.DataFrame:
     # Detect encoding (mainly for shapefiles, others default to UTF-8)
     encoding = _detect_file_encoding(file_path)
     logger.warning("Detected encoding: %s", encoding)
-    # Reading with detected encoding
-    data = gpd.read_file(file_path, encoding=encoding)  # type: ignore[arg-type]
-
-    return data
+    return gpd.read_file(file_path, rows=rows, encoding=encoding)  # type: ignore[arg-type]
 
 
 def ingest_data_from_file_into_postgis(
@@ -179,8 +188,25 @@ def ingest_data_from_ftp_into_postgis(
             # Download FTP file using urlretrieve
             urlretrieve(ftp_url_with_auth, temp_file_path)
 
-            data = _read_file_encoded(str(temp_file_path))
-            write_data_to_postgis(data, table_name, engine, schema)
+            i = 0
+            while True:
+                data = _read_file_encoded(str(temp_file_path), i)
+                if data.empty:
+                    break
+                write_data_to_postgis(
+                    data, table_name, engine, schema, if_exists="replace" if i == 0 else "append"
+                )
+                logger.debug(
+                    "Ingested chunk %s (%s rows) from FTP %s into table %s",
+                    i,
+                    len(data),
+                    url,
+                    table_name,
+                )
+                # A short read means the file is exhausted — avoid an extra empty read.
+                if len(data) < CHUNK_SIZE:
+                    break
+                i += 1
 
     # TODO: handle error for frontend
     except URLError as e:
@@ -279,8 +305,29 @@ def ingest_data_from_url_into_postgis(
                 with open(temp_file_path, "wb") as temp_file:
                     temp_file.write(content)
 
-                data = _read_file_encoded(str(temp_file_path))
-                write_data_to_postgis(data, table_name, engine, schema)
+                i = 0
+                while True:
+                    data = _read_file_encoded(str(temp_file_path), i)
+                    if data.empty:
+                        break
+                    write_data_to_postgis(
+                        data,
+                        table_name,
+                        engine,
+                        schema,
+                        if_exists="replace" if i == 0 else "append",
+                    )
+                    logger.debug(
+                        "Ingested chunk %s (%s rows) from URL %s into table %s",
+                        i,
+                        len(data),
+                        url,
+                        table_name,
+                    )
+                    # A short read means the file is exhausted — avoid an extra empty read.
+                    if len(data) < CHUNK_SIZE:
+                        break
+                    i += 1
     except Exception as e:
         logger.error(f"Error ingesting data from URL {url}: {e}")
         raise
@@ -316,15 +363,43 @@ def ingest_data_from_database_into_postgis(
         table = Table(source_table, metadata, autoload_with=source_engine)
 
         geom = _get_geo_column_from_table(table)
-        query = select(table)
 
-        # Entire table loaded into memory — not suitable for very large tables without chunking
-        if geom is not None:
-            data = gpd.read_postgis(query, con=source_engine, geom_col=geom)  # type: ignore[call-overload]
-        else:
-            data = pd.read_sql(query, source_engine)
+        # A stable ORDER BY is required so that LIMIT/OFFSET pagination returns each row
+        # exactly once. Prefer the primary key; fall back to all columns when absent.
+        order_columns = list(table.primary_key.columns) or list(table.columns)
+        base_query = select(table).order_by(*order_columns)
 
-        write_data_to_postgis(data, target_table, target_engine, target_schema)
+        # Read and write one chunk at a time to keep the memory footprint low for large tables.
+        i = 0
+        while True:
+            query = base_query.limit(CHUNK_SIZE).offset(i * CHUNK_SIZE)
+            if geom is not None:
+                data = gpd.read_postgis(query, con=source_engine, geom_col=geom)  # type: ignore[call-overload]
+            else:
+                data = pd.read_sql(query, source_engine)
+            if data.empty:
+                break
+
+            write_data_to_postgis(
+                data,
+                target_table,
+                target_engine,
+                target_schema,
+                if_exists="replace" if i == 0 else "append",
+            )
+            logger.debug(
+                "Ingested chunk %s (%s rows) from table %s into table %s",
+                i,
+                len(data),
+                source_table,
+                target_table,
+            )
+
+            # A short read means we have reached the end of the table — avoid an extra empty query.
+            if len(data) < CHUNK_SIZE:
+                break
+            i += 1
+
     except Exception as e:
         logger.error(f"Error ingesting data from {source_schema}.{source_table}: {e}")
         raise
@@ -362,12 +437,34 @@ def ingest_data_from_ogc_service_into_postgis(
     gdal_source = f"{gdal_prefix}:{normalized_url}"
     logger.info(f"Ingesting OGC layer '{layer_name}' from {gdal_source} into {table_name}")
     try:
-        gdf = gpd.read_file(gdal_source, layer=layer_name)
-        # OGC API Features collections may have no geometry — treat as tabular data in that case
-        if gdf.geometry.isna().all():
-            logger.info(f"Layer '{layer_name}' has no valid geometries; ingesting as tabular data.")
-            gdf = pd.DataFrame(gdf.drop(columns=str(gdf.geometry.name)))
-        write_data_to_postgis(gdf, table_name, engine, schema)
+        i = 0
+        while True:
+            rows = slice(i * CHUNK_SIZE, i * CHUNK_SIZE + CHUNK_SIZE, None)
+            gdf = gpd.read_file(gdal_source, layer=layer_name, rows=rows)
+            if gdf.empty:
+                break
+            chunk_len = len(gdf)
+            # OGC API Features collections may have no geometry — treat as tabular data in that case
+            data: gpd.GeoDataFrame | pd.DataFrame = gdf
+            if gdf.geometry.isna().all():
+                logger.info(
+                    f"Layer '{layer_name}' has no valid geometries; ingesting as tabular data."
+                )
+                data = pd.DataFrame(gdf.drop(columns=str(gdf.geometry.name)))
+            write_data_to_postgis(
+                data, table_name, engine, schema, if_exists="replace" if i == 0 else "append"
+            )
+            logger.debug(
+                "Ingested chunk %s (%s rows) from OGC service %s into table %s",
+                i,
+                chunk_len,
+                gdal_source,
+                table_name,
+            )
+            # A short read means the layer is exhausted — avoid an extra empty request.
+            if chunk_len < CHUNK_SIZE:
+                break
+            i += 1
     except Exception as e:
         logger.error(f"Error ingesting OGC layer '{layer_name}' from {gdal_source}: {e}")
         raise
@@ -487,6 +584,7 @@ def write_data_to_postgis(
     engine: Engine,
     schema: str = DEFAULT_SCHEMA,
     create_id: bool = False,
+    if_exists: Literal["fail", "replace", "append"] = "replace",
 ) -> None:
     """Write a GeoDataFrame or DataFrame to a PostGIS table.
 
@@ -511,7 +609,7 @@ def write_data_to_postgis(
                 data.drop(columns=[DEFAULT_GEOMETRY_COLUMN], inplace=True)
 
             # Write data to PostGIS as a regular table
-            data.to_sql(table_name, engine, if_exists="replace", schema=schema, index=False)
+            data.to_sql(table_name, engine, if_exists=if_exists, schema=schema, index=False)
         else:  # GeoDataFrame
             # Ensure the geometry column is named 'geom' for PostGIS convention
             if data.active_geometry_name is None:
@@ -544,7 +642,7 @@ def write_data_to_postgis(
                     data.rename_geometry(DEFAULT_GEOMETRY_COLUMN, inplace=True)
 
             # Write data to PostGIS
-            data.to_postgis(table_name, engine, if_exists="replace", schema=schema, index=False)
+            data.to_postgis(table_name, engine, if_exists=if_exists, schema=schema, index=False)
 
         if create_id:
             with engine.connect() as conn:

--- a/libs/data_manipulation/src/data_manipulation/ingestion.py
+++ b/libs/data_manipulation/src/data_manipulation/ingestion.py
@@ -10,6 +10,7 @@ from urllib.request import urlretrieve
 import chardet
 import geopandas as gpd
 import pandas as pd
+import pyarrow.parquet as pq
 import requests
 from geoalchemy2 import Geometry
 from sqlalchemy import MetaData, Table, func, select, text
@@ -94,12 +95,13 @@ def _read_file_encoded(file_path: str, i: int = 0) -> gpd.GeoDataFrame | pd.Data
     # Parquet is columnar and not row-sliceable cheaply: read it fully on the first
     # chunk and signal completion afterwards to avoid re-reading / duplicating rows.
     if Path(file_path).suffix.lower() in (".parquet", ".geoparquet"):
-        if i > 0:
+        ds = pq.ParquetDataset(file_path)
+        if i > len(ds.fragments):
             return gpd.GeoDataFrame()
         try:
-            return gpd.read_parquet(file_path)  # type: ignore[arg-type]
+            return gpd.read_parquet(ds.fragments[i].path)  # type: ignore[arg-type]
         except ValueError:
-            return pd.read_parquet(file_path)
+            return pd.read_parquet(ds.fragments[i].path)
 
     try:
         # Try reading with UTF-8 first (common default)

--- a/libs/data_manipulation/src/data_manipulation/ingestion.py
+++ b/libs/data_manipulation/src/data_manipulation/ingestion.py
@@ -659,8 +659,25 @@ def write_data_to_postgis(
                     logger.info(f"Renaming active geometry column to '{DEFAULT_GEOMETRY_COLUMN}'")
                     data.rename_geometry(DEFAULT_GEOMETRY_COLUMN, inplace=True)
 
-            # Write data to PostGIS
-            data.to_postgis(table_name, engine, if_exists=if_exists, schema=schema, index=False)
+            # Write data to PostGIS. Force a generic GEOMETRY column type (instead of letting
+            # GeoPandas infer Point/LineString/... from the current frame) so that chunked
+            # appends with heterogeneous geometry types — or a first chunk that happens to be
+            # homogeneous — don't clash with later chunks. The SRID is pinned to the data CRS
+            # so PostGIS still rejects mismatched projections.
+            geom_dtype: dict[str, Geometry] | None = None
+            if data.active_geometry_name is not None:
+                srid = data.crs.to_epsg() if data.crs is not None else None
+                geom_dtype = {
+                    data.active_geometry_name: Geometry(geometry_type="GEOMETRY", srid=srid or 0)
+                }
+            data.to_postgis(
+                table_name,
+                engine,
+                if_exists=if_exists,
+                schema=schema,
+                index=False,
+                dtype=geom_dtype,
+            )
 
         if create_id:
             with engine.connect() as conn:

--- a/libs/data_manipulation/src/data_manipulation/ingestion.py
+++ b/libs/data_manipulation/src/data_manipulation/ingestion.py
@@ -1,10 +1,11 @@
 import logging
 import re
 import tempfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Literal
 from urllib.error import URLError
-from urllib.parse import quote, unquote, urlparse
+from urllib.parse import quote, unquote, urlencode, urlparse, urlunparse
 from urllib.request import urlretrieve
 
 import chardet
@@ -409,11 +410,60 @@ def ingest_data_from_database_into_postgis(
 
 _GDAL_PROTOCOL_PREFIX = {"wfs": "WFS", "ogcFeatures": "OAPIF"}
 _OAPIF_COLLECTIONS_RE = re.compile(r"/collections(/.*)?$")
+_WFS_JSON_FORMATS = ("application/json", "application/geo+json", "json", "geojson")
 
 
 def _normalize_oapif_url(url: str) -> str:
     """Strip /collections[/...] suffixes so GDAL's OAPIF driver receives the service root."""
     return _OAPIF_COLLECTIONS_RE.sub("", url.rstrip("/"))
+
+
+def _wfs_json_output_format(service_url: str) -> str | None:
+    """Return the first JSON-compatible outputFormat advertised by GetCapabilities, or None."""
+    try:
+        resp = requests.get(
+            service_url,
+            params={"SERVICE": "WFS", "REQUEST": "GetCapabilities"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        root = ET.fromstring(resp.content)
+        advertised = {
+            el.text.strip().lower()
+            for el in root.iter()
+            if (el.tag.split("}")[-1] if "}" in el.tag else el.tag) == "Value" and el.text
+        }
+        for fmt in _WFS_JSON_FORMATS:
+            if fmt in advertised:
+                return fmt
+    except Exception as exc:
+        logger.warning("Could not read WFS GetCapabilities from %s: %s", service_url, exc)
+    return None
+
+
+def _wfs_geojson_chunk_url(
+    service_url: str,
+    layer_name: str,
+    offset: int,
+    count: int,
+    output_format: str = "application/json",
+) -> str:
+    """Build a WFS 2.0 GetFeature URL requesting JSON output with pagination.
+
+    Bypasses the GML driver (and its curved-geometry issues) by requesting
+    a JSON format directly from the server.
+    """
+    parsed = urlparse(service_url)
+    params = {
+        "SERVICE": "WFS",
+        "VERSION": "2.0.0",
+        "REQUEST": "GetFeature",
+        "TYPENAMES": layer_name,
+        "OUTPUTFORMAT": output_format,
+        "startIndex": str(offset),
+        "count": str(count),
+    }
+    return urlunparse(parsed._replace(query=urlencode(params)))
 
 
 def ingest_data_from_ogc_service_into_postgis(
@@ -438,11 +488,32 @@ def ingest_data_from_ogc_service_into_postgis(
     normalized_url = _normalize_oapif_url(service_url) if protocol == "ogcFeatures" else service_url
     gdal_source = f"{gdal_prefix}:{normalized_url}"
     logger.info(f"Ingesting OGC layer '{layer_name}' from {gdal_source} into {table_name}")
+
+    wfs_json_fmt = _wfs_json_output_format(service_url) if protocol == "wfs" else None
+    use_wfs_fallback = protocol == "wfs" and wfs_json_fmt is None
+    if use_wfs_fallback:
+        logger.warning(
+            "WFS at %s does not advertise a JSON output format; falling back to default WFS output format",
+            service_url,
+        )
+    else:
+        logger.info(
+            "WFS at %s advertises JSON output format '%s'; using it for chunked ingestion",
+            service_url,
+            wfs_json_fmt,
+        )
+
     try:
         i = 0
         while True:
-            rows = slice(i * CHUNK_SIZE, i * CHUNK_SIZE + CHUNK_SIZE, None)
-            gdf = gpd.read_file(gdal_source, layer=layer_name, rows=rows)
+            if wfs_json_fmt:
+                url = _wfs_geojson_chunk_url(
+                    service_url, layer_name, i * CHUNK_SIZE, CHUNK_SIZE, wfs_json_fmt
+                )
+                gdf = gpd.read_file(url)
+            else:
+                rows = slice(i * CHUNK_SIZE, i * CHUNK_SIZE + CHUNK_SIZE, None)
+                gdf = gpd.read_file(gdal_source, layer=layer_name, rows=rows)
             if gdf.empty:
                 break
             chunk_len = len(gdf)

--- a/libs/data_manipulation/src/data_manipulation/ingestion.py
+++ b/libs/data_manipulation/src/data_manipulation/ingestion.py
@@ -476,6 +476,7 @@ def read_data_from_postgis(
     schema: str | None = None,
     limit: int | None = None,
     columns: list[ColumnConfig] | None = None,
+    offset: int | None = None,
 ) -> pd.DataFrame:
     """Read data from a PostGIS table.
 
@@ -494,6 +495,9 @@ def read_data_from_postgis(
             excluded columns are omitted from the SELECT and active filters are
             applied as WHERE clauses.  When ``None``, all columns are returned
             without filtering.
+        offset: Number of rows to skip (applied after filters).  When provided,
+            a stable ``ORDER BY`` is added so that ``LIMIT``/``OFFSET`` pagination
+            returns each row exactly once across successive calls.
 
     Returns:
         GeoDataFrame or DataFrame containing the (filtered) table data.
@@ -523,12 +527,21 @@ def read_data_from_postgis(
                 query = query.where(*where_clauses)
 
             has_geom = any(col.key == DEFAULT_GEOMETRY_COLUMN for col in select_cols)
+            order_columns = list(select_cols)
         else:
             query = select(table)
             has_geom = DEFAULT_GEOMETRY_COLUMN in table.c
+            order_columns = list(table.primary_key.columns) or list(table.columns)
+
+        # A stable ORDER BY is required for deterministic LIMIT/OFFSET pagination.
+        if offset is not None:
+            query = query.order_by(*order_columns)
 
         if limit is not None and limit > 0:
             query = query.limit(limit)
+
+        if offset is not None and offset > 0:
+            query = query.offset(offset)
 
         # Pass the Select object directly — both pd.read_sql and gpd.read_postgis
         # accept a SQLAlchemy Selectable natively in SQLAlchemy 2.x.
@@ -548,6 +561,7 @@ def read_and_transform_data(
     schema: str | None = None,
     config: IntegrityTransformation | None = None,
     limit: int | None = None,
+    offset: int | None = None,
 ) -> pd.DataFrame:
     """Single pipeline entry point: read data and apply all transformations.
 
@@ -565,12 +579,16 @@ def read_and_transform_data(
         config: Transformation configuration.  ``None`` = return raw data
             unchanged (no column filtering, no transformations).
         limit: Row limit (``None`` = all rows).
+        offset: Number of rows to skip for chunked reads (``None`` = from the
+            start).  Enables deterministic ``LIMIT``/``OFFSET`` pagination.
 
     Returns:
         Transformed GeoDataFrame or DataFrame.
     """
     columns = config.columns if config is not None else None
-    data = read_data_from_postgis(table_name, engine, schema=schema, limit=limit, columns=columns)
+    data = read_data_from_postgis(
+        table_name, engine, schema=schema, limit=limit, columns=columns, offset=offset
+    )
 
     if config is None:
         return data

--- a/libs/data_manipulation/tests/test_ingestion.py
+++ b/libs/data_manipulation/tests/test_ingestion.py
@@ -688,9 +688,36 @@ class TestWriteDataToPostgis:
         with patch.object(gdf, "to_postgis") as mock_to_postgis:
             write_data_to_postgis(gdf, "test_table", mock_engine, "public")
 
-            mock_to_postgis.assert_called_once_with(
-                "test_table", mock_engine, if_exists="replace", schema="public", index=False
-            )
+            mock_to_postgis.assert_called_once()
+            args, kwargs = mock_to_postgis.call_args
+            assert args == ("test_table", mock_engine)
+            assert kwargs["if_exists"] == "replace"
+            assert kwargs["schema"] == "public"
+            assert kwargs["index"] is False
+            # The geometry column must be created as a generic GEOMETRY type so that
+            # chunked appends with mixed geometry types do not clash.
+            geom_dtype = kwargs["dtype"]["geom"]
+            assert geom_dtype.geometry_type == "GEOMETRY"
+
+    @patch("data_manipulation.ingestion._get_table_row_count")
+    def test_write_geodataframe_pins_srid_from_crs(
+        self,
+        mock_get_row_count: Mock,
+        mock_engine: Mock,
+    ) -> None:
+        """The generic GEOMETRY column inherits the SRID of the GeoDataFrame CRS."""
+        gdf = GeoDataFrame(
+            {"col1": [1, 2]},
+            geometry=gpd.GeoSeries([Point(0, 0), Point(1, 1)], name="geom", crs="EPSG:4326"),
+        )
+        mock_get_row_count.return_value = 2
+
+        with patch.object(gdf, "to_postgis") as mock_to_postgis:
+            write_data_to_postgis(gdf, "test_table", mock_engine, "public")
+
+            geom_dtype = mock_to_postgis.call_args.kwargs["dtype"]["geom"]
+            assert geom_dtype.geometry_type == "GEOMETRY"
+            assert geom_dtype.srid == 4326
 
     @patch("data_manipulation.ingestion._get_table_row_count")
     def test_write_geodataframe_renames_geometry_column(

--- a/libs/data_manipulation/tests/test_ingestion.py
+++ b/libs/data_manipulation/tests/test_ingestion.py
@@ -14,6 +14,7 @@ from sqlalchemy.engine import Engine
 from data_manipulation import IntegrityTransformation, apply_transformations
 from data_manipulation.constants import POSTGIS_TABLE_NAME_MAX_LENGTH
 from data_manipulation.ingestion import (
+    CHUNK_SIZE,
     _read_file_encoded,  # pyright: ignore[reportPrivateUsage]
     ingest_data_from_database_into_postgis,
     ingest_data_from_file_into_postgis,
@@ -35,7 +36,9 @@ class TestReadFileEncodedParquet:
 
         result = _read_file_encoded("test.geoparquet")
 
-        mock_read_parquet.assert_called_once_with("test.geoparquet")
+        mock_read_parquet.assert_called_once_with(
+            "test.geoparquet", rows=slice(0, CHUNK_SIZE, None)
+        )
         assert result is mock_gdf
 
     @patch("data_manipulation.ingestion.pd.read_parquet")
@@ -49,8 +52,12 @@ class TestReadFileEncodedParquet:
 
         result = _read_file_encoded("test.parquet")
 
-        mock_gpd_read_parquet.assert_called_once_with("test.parquet")
-        mock_pd_read_parquet.assert_called_once_with("test.parquet")
+        mock_gpd_read_parquet.assert_called_once_with(
+            "test.parquet", rows=slice(0, CHUNK_SIZE, None)
+        )
+        mock_pd_read_parquet.assert_called_once_with(
+            "test.parquet", rows=slice(0, CHUNK_SIZE, None)
+        )
         assert result is mock_df
 
     @patch("data_manipulation.ingestion.gpd.read_parquet")
@@ -60,7 +67,7 @@ class TestReadFileEncodedParquet:
 
         result = _read_file_encoded("test.parquet")
 
-        mock_read_parquet.assert_called_once_with("test.parquet")
+        mock_read_parquet.assert_called_once_with("test.parquet", rows=slice(0, CHUNK_SIZE, None))
         assert result is mock_gdf
 
 
@@ -72,98 +79,61 @@ class TestIngestDataFromFileIntoPostgis:
         """Create a mock SQLAlchemy engine."""
         return Mock(spec=Engine)
 
-    @patch("data_manipulation.ingestion.write_data_to_postgis")
-    @patch("data_manipulation.ingestion.gpd.read_file")
-    @patch("data_manipulation.ingestion._detect_file_encoding")
-    def test_ingest_with_detected_encoding_success(
+    @patch("data_manipulation.ingestion.ingest_data_from_url_into_postgis")
+    def test_ingest_delegates_to_url_function(
         self,
-        mock_detect_encoding: Mock,
-        mock_read_file: Mock,
-        mock_write_data: Mock,
+        mock_ingest_url: Mock,
         mock_engine: Mock,
     ) -> None:
-        """Test successful ingestion with detected encoding."""
+        """A local file path is delegated to the URL ingestion function."""
+        ingest_data_from_file_into_postgis("test.geojson", "test_table", mock_engine, "public")
 
-        mock_detect_encoding.return_value = "utf-8"
+        mock_ingest_url.assert_called_once_with("test.geojson", "test_table", mock_engine, "public")
+
+    @patch("data_manipulation.ingestion.ingest_data_from_url_into_postgis")
+    def test_ingest_propagates_errors(
+        self,
+        mock_ingest_url: Mock,
+        mock_engine: Mock,
+    ) -> None:
+        """Errors raised while ingesting are propagated to the caller."""
+        mock_ingest_url.side_effect = Exception("boom")
+
+        with pytest.raises(Exception, match="boom"):
+            ingest_data_from_file_into_postgis("test.geojson", "test_table", mock_engine, "public")
+
+    @patch("data_manipulation.ingestion.gpd.read_file")
+    def test_read_file_encoded_utf8_success(self, mock_read_file: Mock) -> None:
+        """The first chunk is read without an explicit encoding (UTF-8 default)."""
         mock_gdf = GeoDataFrame({"col1": [1, 2], "geometry": [Point(0, 0), Point(1, 1)]})
         mock_read_file.return_value = mock_gdf
 
-        ingest_data_from_file_into_postgis("test.geojson", "test_table", mock_engine, "public")
+        result = _read_file_encoded("test.geojson")
 
-        mock_detect_encoding.assert_called_once_with("test.geojson")
-        mock_read_file.assert_called_once_with("test.geojson", encoding="utf-8")
-        mock_write_data.assert_called_once_with(mock_gdf, "test_table", mock_engine, "public")
+        mock_read_file.assert_called_once_with("test.geojson", rows=slice(0, CHUNK_SIZE, None))
+        assert result is mock_gdf
 
-    @patch("data_manipulation.ingestion.write_data_to_postgis")
     @patch("data_manipulation.ingestion.gpd.read_file")
     @patch("data_manipulation.ingestion._detect_file_encoding")
-    def test_ingest_with_encoding_fallback_to_latin1(
+    def test_read_file_encoded_falls_back_to_detected_encoding(
         self,
         mock_detect_encoding: Mock,
         mock_read_file: Mock,
-        mock_write_data: Mock,
-        mock_engine: Mock,
     ) -> None:
-        """Test ingestion falls back to latin-1 when UTF-8 fails."""
-
-        mock_detect_encoding.return_value = "utf-8"
+        """On a UnicodeDecodeError the detected encoding is used for a second attempt."""
+        mock_detect_encoding.return_value = "latin-1"
         mock_gdf = GeoDataFrame({"col1": [1, 2], "geometry": [Point(0, 0), Point(1, 1)]})
-
-        # First call with utf-8 raises UnicodeDecodeError, second call with latin-1 succeeds
         mock_read_file.side_effect = [UnicodeDecodeError("utf-8", b"", 0, 1, ""), mock_gdf]
 
-        ingest_data_from_file_into_postgis("test.geojson", "test_table", mock_engine, "public")
+        result = _read_file_encoded("test.shp")
 
         assert mock_read_file.call_count == 2
-        mock_read_file.assert_any_call("test.geojson", encoding="utf-8")
-        mock_read_file.assert_any_call("test.geojson", encoding="latin-1")
-        mock_write_data.assert_called_once_with(mock_gdf, "test_table", mock_engine, "public")
-
-    @patch("data_manipulation.ingestion.write_data_to_postgis")
-    @patch("data_manipulation.ingestion.gpd.read_file")
-    @patch("data_manipulation.ingestion._detect_file_encoding")
-    def test_ingest_with_encoding_fallback_to_cp1252(
-        self,
-        mock_detect_encoding: Mock,
-        mock_read_file: Mock,
-        mock_write_data: Mock,
-        mock_engine: Mock,
-    ) -> None:
-        """Test ingestion falls back to cp1252 when UTF-8 and latin-1 fail."""
-
-        mock_detect_encoding.return_value = "utf-8"
-        mock_gdf = GeoDataFrame({"col1": [1, 2], "geometry": [Point(0, 0), Point(1, 1)]})
-
-        # First two calls fail, third call with cp1252 succeeds
-        mock_read_file.side_effect = [
-            UnicodeDecodeError("utf-8", b"", 0, 1, ""),
-            UnicodeDecodeError("latin-1", b"", 0, 1, ""),
-            mock_gdf,
-        ]
-
-        ingest_data_from_file_into_postgis("test.geojson", "test_table", mock_engine, "public")
-
-        assert mock_read_file.call_count == 3
-        mock_read_file.assert_any_call("test.geojson", encoding="utf-8")
-        mock_read_file.assert_any_call("test.geojson", encoding="latin-1")
-        mock_read_file.assert_any_call("test.geojson", encoding="cp1252")
-        mock_write_data.assert_called_once_with(mock_gdf, "test_table", mock_engine, "public")
-
-    @patch("data_manipulation.ingestion.gpd.read_file")
-    @patch("data_manipulation.ingestion._detect_file_encoding")
-    def test_ingest_raises_exception_on_error(
-        self,
-        mock_detect_encoding: Mock,
-        mock_read_file: Mock,
-        mock_engine: Mock,
-    ) -> None:
-        """Test ingestion raises exception when all encoding attempts fail."""
-
-        mock_detect_encoding.return_value = "utf-8"
-        mock_read_file.side_effect = Exception("Failed to read file")
-
-        with pytest.raises(Exception, match="Failed to read file"):
-            ingest_data_from_file_into_postgis("test.geojson", "test_table", mock_engine, "public")
+        mock_read_file.assert_any_call("test.shp", rows=slice(0, CHUNK_SIZE, None))
+        mock_read_file.assert_any_call(
+            "test.shp", rows=slice(0, CHUNK_SIZE, None), encoding="latin-1"
+        )
+        mock_detect_encoding.assert_called_once_with("test.shp")
+        assert result is mock_gdf
 
 
 class TestIngestDataFromUrlIntoPostgis:
@@ -205,7 +175,9 @@ class TestIngestDataFromUrlIntoPostgis:
             "http://example.com/data.geojson", auth=None, timeout=300
         )
         mock_read_file.assert_called_once()
-        mock_write_data.assert_called_once_with(mock_gdf, "test_table", mock_engine, "public")
+        mock_write_data.assert_called_once_with(
+            mock_gdf, "test_table", mock_engine, "public", if_exists="replace"
+        )
 
     @patch("data_manipulation.ingestion.write_data_to_postgis")
     @patch("data_manipulation.ingestion.gpd.read_file")
@@ -326,7 +298,9 @@ class TestIngestDataFromUrlIntoPostgis:
         mock_read_parquet.assert_called_once()
         path_arg = mock_read_parquet.call_args.args[0]
         assert path_arg.endswith(".parquet")
-        mock_write_data.assert_called_once_with(mock_gdf, "test_table", mock_engine, "public")
+        mock_write_data.assert_called_once_with(
+            mock_gdf, "test_table", mock_engine, "public", if_exists="replace"
+        )
 
     @patch("data_manipulation.ingestion.write_data_to_postgis")
     @patch("data_manipulation.ingestion.gpd.read_parquet")
@@ -352,7 +326,9 @@ class TestIngestDataFromUrlIntoPostgis:
         mock_read_parquet.assert_called_once()
         path_arg = mock_read_parquet.call_args.args[0]
         assert path_arg.endswith(".geoparquet")
-        mock_write_data.assert_called_once_with(mock_gdf, "test_table", mock_engine, "public")
+        mock_write_data.assert_called_once_with(
+            mock_gdf, "test_table", mock_engine, "public", if_exists="replace"
+        )
 
     @patch("data_manipulation.ingestion.write_data_to_postgis")
     @patch("data_manipulation.ingestion.gpd.read_parquet")
@@ -378,7 +354,9 @@ class TestIngestDataFromUrlIntoPostgis:
         mock_read_parquet.assert_called_once()
         path_arg = mock_read_parquet.call_args.args[0]
         assert path_arg.endswith("export.parquet")
-        mock_write_data.assert_called_once_with(mock_gdf, "test_table", mock_engine, "public")
+        mock_write_data.assert_called_once_with(
+            mock_gdf, "test_table", mock_engine, "public", if_exists="replace"
+        )
 
 
 class TestIngestDataFromFtpIntoPostgis:
@@ -413,7 +391,9 @@ class TestIngestDataFromFtpIntoPostgis:
         # Verify URL without auth is passed
         assert "ftp://example.com/data.geojson" in str(mock_urlretrieve.call_args[0][0])
         mock_read_file.assert_called_once()
-        mock_write_data.assert_called_once_with(mock_gdf, "test_table", mock_engine, "public")
+        mock_write_data.assert_called_once_with(
+            mock_gdf, "test_table", mock_engine, "public", if_exists="replace"
+        )
 
     @patch("data_manipulation.ingestion.write_data_to_postgis")
     @patch("data_manipulation.ingestion._read_file_encoded")
@@ -915,15 +895,19 @@ class TestIngestDataFromDatabaseIntoPostgis:
         )
 
         mock_read_sql.assert_called_once()
-        mock_write.assert_called_once_with(df, "staging_table", mock_target_engine, "staging")
+        mock_write.assert_called_once_with(
+            df, "staging_table", mock_target_engine, "staging", if_exists="replace"
+        )
 
     @patch("data_manipulation.ingestion.write_data_to_postgis")
     @patch("data_manipulation.ingestion.gpd.read_postgis")
     @patch("data_manipulation.ingestion.select")
     @patch("data_manipulation.ingestion.Table")
     @patch("data_manipulation.ingestion.MetaData")
+    @patch("data_manipulation.ingestion._get_geo_column_from_table", return_value="geom")
     def test_ingest_geographic_table(
         self,
+        mock_get_geo: Mock,
         mock_metadata: Mock,
         mock_table_cls: Mock,
         mock_select: Mock,
@@ -949,7 +933,9 @@ class TestIngestDataFromDatabaseIntoPostgis:
         )
 
         mock_read_postgis.assert_called_once()
-        mock_write.assert_called_once_with(gdf, "staging_table", mock_target_engine, "staging")
+        mock_write.assert_called_once_with(
+            gdf, "staging_table", mock_target_engine, "staging", if_exists="replace"
+        )
 
     @patch("data_manipulation.ingestion.Table")
     @patch("data_manipulation.ingestion.MetaData")
@@ -1031,8 +1017,12 @@ class TestIngestDataFromOgcServiceIntoPostgis:
             schema="public",
         )
 
-        mock_read_file.assert_called_once_with("WFS:https://example.com/wfs", layer="ns:buildings")
-        mock_write.assert_called_once_with(mock_gdf, "buildings_stg", mock_engine, "public")
+        mock_read_file.assert_called_once_with(
+            "WFS:https://example.com/wfs", layer="ns:buildings", rows=slice(0, CHUNK_SIZE, None)
+        )
+        mock_write.assert_called_once_with(
+            mock_gdf, "buildings_stg", mock_engine, "public", if_exists="replace"
+        )
 
     @patch("data_manipulation.ingestion.write_data_to_postgis")
     @patch("data_manipulation.ingestion.gpd.read_file")
@@ -1055,8 +1045,12 @@ class TestIngestDataFromOgcServiceIntoPostgis:
             schema="public",
         )
 
-        mock_read_file.assert_called_once_with("OAPIF:https://example.com/ogcapi", layer="parcels")
-        mock_write.assert_called_once_with(mock_gdf, "parcels_stg", mock_engine, "public")
+        mock_read_file.assert_called_once_with(
+            "OAPIF:https://example.com/ogcapi", layer="parcels", rows=slice(0, CHUNK_SIZE, None)
+        )
+        mock_write.assert_called_once_with(
+            mock_gdf, "parcels_stg", mock_engine, "public", if_exists="replace"
+        )
 
     @patch("data_manipulation.ingestion.write_data_to_postgis")
     @patch("data_manipulation.ingestion.gpd.read_file")
@@ -1158,4 +1152,6 @@ def test_oapif_url_normalized_before_gdal(
         engine=Mock(spec=Engine),
     )
 
-    mock_read_file.assert_called_once_with(expected_gdal_source, layer="my_layer")
+    mock_read_file.assert_called_once_with(
+        expected_gdal_source, layer="my_layer", rows=slice(0, CHUNK_SIZE, None)
+    )

--- a/libs/data_manipulation/tests/test_ingestion.py
+++ b/libs/data_manipulation/tests/test_ingestion.py
@@ -36,9 +36,7 @@ class TestReadFileEncodedParquet:
 
         result = _read_file_encoded("test.geoparquet")
 
-        mock_read_parquet.assert_called_once_with(
-            "test.geoparquet", rows=slice(0, CHUNK_SIZE, None)
-        )
+        mock_read_parquet.assert_called_once_with("test.geoparquet")
         assert result is mock_gdf
 
     @patch("data_manipulation.ingestion.pd.read_parquet")
@@ -52,12 +50,8 @@ class TestReadFileEncodedParquet:
 
         result = _read_file_encoded("test.parquet")
 
-        mock_gpd_read_parquet.assert_called_once_with(
-            "test.parquet", rows=slice(0, CHUNK_SIZE, None)
-        )
-        mock_pd_read_parquet.assert_called_once_with(
-            "test.parquet", rows=slice(0, CHUNK_SIZE, None)
-        )
+        mock_gpd_read_parquet.assert_called_once_with("test.parquet")
+        mock_pd_read_parquet.assert_called_once_with("test.parquet")
         assert result is mock_df
 
     @patch("data_manipulation.ingestion.gpd.read_parquet")
@@ -67,7 +61,7 @@ class TestReadFileEncodedParquet:
 
         result = _read_file_encoded("test.parquet")
 
-        mock_read_parquet.assert_called_once_with("test.parquet", rows=slice(0, CHUNK_SIZE, None))
+        mock_read_parquet.assert_called_once_with("test.parquet")
         assert result is mock_gdf
 
 


### PR DESCRIPTION
This PR allows to maintain memory usage to a reasonable level.
Only parquet can't accept chunking

Also use json geojson by default for wfs to avoid error with shapely: `Nonlinear geometry types are not currently supported`

Tested on all ingestion methods. 
50000 chunksize has been set with monitoring staging and process dag and memory usage and trying to find the right balance between time and memory consumption