### PR TITLE
Fixes: fallback to get request for urls import and fix GS publishing for preffilled integrity links

### DIFF
--- a/apps/backend/src/api/routes/ingestion/integrity_link.py
+++ b/apps/backend/src/api/routes/ingestion/integrity_link.py
@@ -609,15 +609,19 @@ def toggle_publish_gs_integrity_link(
         session,
         group_ids,
     )
-    if not integrity_link.final_table_name:
+    workspace = integrity_link.integrity_organization.lower()
+    final_table_name = integrity_link.final_table_name
+    if integrity_link.source_import_type == ImportType.PREFILLED:
+        if parts := integrity_link.parse_data_id():
+            workspace, final_table_name = parts[0].lower(), parts[1].lower()
+
+    if not final_table_name:
         raise HTTPException(
             status_code=400,
             detail="IntegrityLink has no associated layer to publish/unpublish",
         )
 
-    acl_layer_name = GeoServerService.make_acl_layer_name(
-        integrity_link.integrity_organization, integrity_link.final_table_name
-    )
+    acl_layer_name = GeoServerService.make_acl_layer_name(workspace, final_table_name)
     gs_read_roles: list[str] | None = None
     try:
         if publish:
@@ -650,7 +654,7 @@ def toggle_publish_gs_integrity_link(
         )
         action = "Published" if publish else "Unpublished"
         logger.info(
-            f"{action} GeoServer layer {integrity_link.integrity_organization}/{integrity_link.final_table_name} "
+            f"{action} GeoServer layer {workspace}/{final_table_name} "
             f"for IntegrityLink {integrity_link_id}"
         )
 

--- a/apps/backend/src/api/routes/ingestion/staging.py
+++ b/apps/backend/src/api/routes/ingestion/staging.py
@@ -336,7 +336,8 @@ def _extract_filetype(filename: str) -> FileType | None:
 def _extract_url_metadata(
     url: str, auth_enabled: bool = False, username: str | None = None, password: str | None = None
 ) -> tuple[str | None, FileType | None]:
-    """Extract file name and file type from a URL using HEAD request.
+    """Extract file name and file type from a URL using a HEAD request, falling back to GET
+    if the server doesn't support HEAD.
 
     Args:
         url: The URL to inspect
@@ -354,13 +355,20 @@ def _extract_url_metadata(
         headers = {
             "Accept": "*/*",
         }
-        head_response = requests.head(
-            url,
-            headers=headers,
-            allow_redirects=True,
-            auth=(username, password) if auth_enabled and username and password else None,
-        )
-        head_response.raise_for_status()
+        auth = (username, password) if auth_enabled and username and password else None
+
+        try:
+            head_response = requests.head(url, headers=headers, allow_redirects=True, auth=auth)
+            head_response.raise_for_status()
+        except requests.RequestException as head_error:
+            # Some servers (e.g. certain WFS endpoints) don't support HEAD requests
+            # properly and error out even though a GET on the same URL works fine.
+            logger.warning(f"HEAD request failed for URL {url} ({head_error}); retrying with GET")
+            head_response = requests.get(
+                url, headers=headers, allow_redirects=True, auth=auth, stream=True
+            )
+            head_response.raise_for_status()
+            head_response.close()
 
         source_file_name = None
         content_disposition = head_response.headers.get("content-disposition")


### PR DESCRIPTION
Two fixes here: 
- Some servers doesn't support head requests. So we now fallback to get requests (stream true to avoid to download it all)
- Prefilled integrity links doesn't have a final table name, so the method was failing