### PR TITLE
feat: add joinable-tables and joinable-columns endpoints

### DIFF
--- a/apps/backend/src/api/routes/ingestion/integrity_links.py
+++ b/apps/backend/src/api/routes/ingestion/integrity_links.py
@@ -2,10 +2,10 @@ from collections.abc import Sequence
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import Column, MetaData, String, Table, exists, or_
 from sqlalchemy import select as sa_select
-from sqlmodel import Session
+from sqlmodel import Session, col
 
 from src.api.deps import (
     DatafeederSessionDep,
@@ -15,8 +15,14 @@ from src.api.deps import (
 )
 from src.core.config import get_data_schema, get_settings, get_staging_schema
 from src.core.logging import get_logger
-from src.core.security import build_access_expr
-from src.models.data_import import ImportType, IntegrityLinkListItem, IntegrityLinkListResponse
+from src.core.security import AccessLevel, build_access_expr, load_authorized_integrity_link
+from src.models.data_import import (
+    ImportType,
+    IntegrityLinkListItem,
+    IntegrityLinkListResponse,
+    JoinableColumn,
+    JoinableTable,
+)
 from src.models.integrity_link import IntegrityLink
 from src.models.integrity_link_rule import IntegrityLinkRule, RuleType
 from src.models.recurrence import RecurrencePreset
@@ -32,6 +38,14 @@ _info_tables = Table(
     MetaData(schema="information_schema"),
     Column("table_schema", String),
     Column("table_name", String),
+)
+
+_info_columns = Table(
+    "columns",
+    MetaData(schema="information_schema"),
+    Column("table_schema", String),
+    Column("table_name", String),
+    Column("column_name", String),
 )
 
 
@@ -76,6 +90,25 @@ def _check_final_existence(rows: Sequence[Any], data_session: Session) -> set[tu
     return existing
 
 
+def _visibility_condition(username: str, group_ids: list[str]) -> Any:
+    """WHERE condition restricting IntegrityLink rows to ones the user may see.
+
+    Only call this for non-admins — admins should see everything unfiltered.
+    """
+    conditions: list[Any] = [IntegrityLink.integrity_owner == username]
+    if group_ids:
+        conditions.append(
+            exists(
+                sa_select(IntegrityLinkRule.id).where(  # type: ignore[reportArgumentType]
+                    IntegrityLinkRule.integrity_link_id == IntegrityLink.id,
+                    IntegrityLinkRule.rule_type == RuleType.METADATA,
+                    IntegrityLinkRule.group_or_role.in_(group_ids),  # type: ignore[attr-defined]
+                )
+            )
+        )
+    return or_(*conditions)
+
+
 @router.get(
     "/",
     response_model=IntegrityLinkListResponse,
@@ -115,18 +148,7 @@ def list_integrity_links(
     if not is_admin:
         # Non-admins see: own datasets + datasets with METADATA rules matching any
         # of the user's group identifiers (org UUID in ORG mode, role UUIDs in ROLE mode).
-        conditions: list[Any] = [IntegrityLink.integrity_owner == geo_ctx.username]
-        if group_ids:
-            conditions.append(
-                exists(
-                    sa_select(IntegrityLinkRule.id).where(  # type: ignore[reportArgumentType]
-                        IntegrityLinkRule.integrity_link_id == IntegrityLink.id,
-                        IntegrityLinkRule.rule_type == RuleType.METADATA,
-                        IntegrityLinkRule.group_or_role.in_(group_ids),  # type: ignore[attr-defined]
-                    )
-                )
-            )
-        query = query.where(or_(*conditions))
+        query = query.where(_visibility_condition(geo_ctx.username, group_ids))
 
     # Apply search filter if provided
     if search:
@@ -235,3 +257,76 @@ def list_integrity_links(
         offset=offset,
         next_offset=next_offset,
     )
+
+
+@router.get(
+    "/joinable-tables",
+    response_model=list[JoinableTable],
+    summary="List tables available for join",
+    description="List tables available for join with role-based filtering. "
+    "Normal users see only their own links, administrators see all links. "
+    "No filtering on COPY mode or reference datasets yet.",
+)
+def list_joinable_tables(
+    session: DatafeederSessionDep,
+    data_session: DataSessionDep,
+    geo_ctx: GeorchestraContextDep,
+    group_ids: GroupIdsDep,
+) -> list[JoinableTable]:
+    """List tables available as join targets, restricted to datasets the caller can see."""
+    query = sa_select(IntegrityLink).where(col(IntegrityLink.final_table_name).is_not(None))
+
+    if not geo_ctx.is_administrator():
+        # Same visibility rule as the main integrity-links list: own datasets +
+        # datasets with a METADATA rule matching the user's org/role — a user
+        # shouldn't be able to discover table/column names of datasets they
+        # otherwise have no access to.
+        query = query.where(_visibility_condition(geo_ctx.username, group_ids))
+
+    links = session.execute(query).scalars().all()  # type: ignore[reportDeprecated]
+
+    existing_final = _check_final_existence([(lnk, None) for lnk in links], data_session)
+
+    return [
+        JoinableTable(
+            id=lnk.id,
+            integrity_title=lnk.integrity_title,
+            table_name=lnk.final_table_name,
+        )
+        for lnk in links
+        if (get_data_schema(lnk.integrity_organization), lnk.final_table_name) in existing_final
+    ]
+
+
+@router.get(
+    "/{integrity_link_id}/joinable-columns",
+    response_model=list[JoinableColumn],
+    summary="List the columns of a joinable table",
+)
+def get_joinable_columns(
+    integrity_link_id: UUID,
+    session: DatafeederSessionDep,
+    data_session: DataSessionDep,
+    geo_ctx: GeorchestraContextDep,
+    group_ids: GroupIdsDep,
+) -> list[JoinableColumn]:
+    """List the columns of a joinable table; 404/403 mirror load_authorized_integrity_link."""
+    link, _ = load_authorized_integrity_link(
+        str(integrity_link_id), AccessLevel.METADATA_READ, geo_ctx, session, group_ids
+    )
+    if not link.final_table_name:
+        raise HTTPException(status_code=404, detail="IntegrityLink has no final table yet")
+
+    schema = get_data_schema(link.integrity_organization)
+    column_names = (
+        data_session.execute(  # type: ignore[reportDeprecated]
+            sa_select(_info_columns.c.column_name).where(
+                _info_columns.c.table_schema == schema,
+                _info_columns.c.table_name == link.final_table_name,
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    return [JoinableColumn(column_name=name) for name in column_names]

--- a/apps/backend/src/models/data_import.py
+++ b/apps/backend/src/models/data_import.py
@@ -188,6 +188,20 @@ class IntegrityLinkListResponse(BaseModel):
     next_offset: int  # raw DB offset to pass verbatim on the next page request
 
 
+class JoinableTable(BaseModel):
+    """A table available as a join target."""
+
+    id: UUID
+    integrity_title: str | None
+    table_name: str
+
+
+class JoinableColumn(BaseModel):
+    """A column of a joinable table."""
+
+    column_name: str
+
+
 class IntegrityLinkResponse(BaseModel):
     """Response model for IntegrityLink entity."""
 

--- a/apps/backend/tests/api/routes/test_integrity_links.py
+++ b/apps/backend/tests/api/routes/test_integrity_links.py
@@ -5,8 +5,14 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 
-from src.api.routes.ingestion.integrity_links import BATCH_SIZE, list_integrity_links
+from src.api.routes.ingestion.integrity_links import (
+    BATCH_SIZE,
+    get_joinable_columns,
+    list_integrity_links,
+    list_joinable_tables,
+)
 from src.models.data_import import ImportType
 from src.models.integrity_link import IntegrityLink
 from src.services.georchestra import GeorchestraContext
@@ -1052,3 +1058,251 @@ class TestListIntegrityLinksVisibility:
         query_str = str(executed_query)
         # Should have OR condition (owner = username OR EXISTS subquery)
         assert "OR" in query_str.upper() or "or" in query_str.lower()
+
+
+class TestListJoinableTables:
+    """Test the list_joinable_tables endpoint."""
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_data_session(self) -> MagicMock:
+        return MagicMock()
+
+    def _link(
+        self, title: str, final_table_name: str | None, owner: str = "user0"
+    ) -> IntegrityLink:
+        return IntegrityLink(
+            id=uuid4(),
+            integrity_title=title,
+            integrity_owner=owner,
+            integrity_organization="testorg",
+            source_import_type=ImportType.URL,
+            final_table_name=final_table_name,
+            created_at=datetime.now(timezone.utc),
+            schedule_enabled=False,
+        )
+
+    def _geo_ctx(self, username: str, roles: set[str] | None = None) -> GeorchestraContext:
+        return GeorchestraContext(
+            username=username,
+            roles=roles or set(),
+            email="",
+            firstname="",
+            lastname="",
+            organization="",
+        )
+
+    def test_owner_sees_own_link_with_existing_final_table(
+        self, mock_session: MagicMock, mock_data_session: MagicMock
+    ) -> None:
+        link = self._link("Roads", "roads_final", owner="user0")
+        mock_session.execute.return_value.scalars.return_value.all.return_value = [link]
+        mock_data_session.execute.return_value.scalars.return_value.all.return_value = [
+            "roads_final"
+        ]
+
+        response = list_joinable_tables(
+            session=mock_session,
+            data_session=mock_data_session,
+            geo_ctx=self._geo_ctx("user0"),
+            group_ids=[],
+        )
+
+        assert len(response) == 1
+        assert response[0].id == link.id
+        assert response[0].integrity_title == "Roads"
+        assert response[0].table_name == "roads_final"
+
+    def test_excludes_link_whose_final_table_does_not_exist(
+        self, mock_session: MagicMock, mock_data_session: MagicMock
+    ) -> None:
+        link = self._link("Ghost", "ghost_final", owner="user0")
+        mock_session.execute.return_value.scalars.return_value.all.return_value = [link]
+        mock_data_session.execute.return_value.scalars.return_value.all.return_value = []
+
+        response = list_joinable_tables(
+            session=mock_session,
+            data_session=mock_data_session,
+            geo_ctx=self._geo_ctx("user0"),
+            group_ids=[],
+        )
+
+        assert response == []
+
+    def test_non_owner_without_rule_does_not_see_link(
+        self, mock_session: MagicMock, mock_data_session: MagicMock
+    ) -> None:
+        # Query itself is expected to filter server-side; a mocked session can't apply
+        # the real WHERE clause, so simulate the DB already having excluded the row.
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+        mock_data_session.execute.return_value.scalars.return_value.all.return_value = []
+
+        response = list_joinable_tables(
+            session=mock_session,
+            data_session=mock_data_session,
+            geo_ctx=self._geo_ctx("someone_else"),
+            group_ids=[],
+        )
+
+        assert response == []
+
+    def test_query_restricted_to_owner_or_rule_for_non_admin(
+        self, mock_session: MagicMock, mock_data_session: MagicMock
+    ) -> None:
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+        mock_data_session.execute.return_value.scalars.return_value.all.return_value = []
+
+        list_joinable_tables(
+            session=mock_session,
+            data_session=mock_data_session,
+            geo_ctx=self._geo_ctx("user1"),
+            group_ids=[],
+        )
+
+        executed_query = mock_session.execute.call_args_list[0][0][0]
+        assert "user1" in str(executed_query.compile(compile_kwargs={"literal_binds": True}))
+
+    def test_admin_query_is_not_restricted_to_owner(
+        self, mock_session: MagicMock, mock_data_session: MagicMock
+    ) -> None:
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+        mock_data_session.execute.return_value.scalars.return_value.all.return_value = []
+
+        list_joinable_tables(
+            session=mock_session,
+            data_session=mock_data_session,
+            geo_ctx=self._geo_ctx("admin", {"ADMINISTRATOR"}),
+            group_ids=[],
+        )
+
+        executed_query = mock_session.execute.call_args_list[0][0][0]
+        query_str = str(executed_query.compile(compile_kwargs={"literal_binds": True}))
+        assert "integrity_owner =" not in query_str
+
+
+class TestGetJoinableColumns:
+    """Test the get_joinable_columns endpoint."""
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_data_session(self) -> MagicMock:
+        return MagicMock()
+
+    def _geo_ctx(self, username: str, roles: set[str] | None = None) -> GeorchestraContext:
+        return GeorchestraContext(
+            username=username,
+            roles=roles or set(),
+            email="",
+            firstname="",
+            lastname="",
+            organization="",
+        )
+
+    def test_owner_returns_columns_of_final_table(
+        self, mock_session: MagicMock, mock_data_session: MagicMock
+    ) -> None:
+        link = IntegrityLink(
+            id=uuid4(),
+            integrity_title="Roads",
+            integrity_owner="user0",
+            integrity_organization="testorg",
+            source_import_type=ImportType.URL,
+            final_table_name="roads_final",
+            created_at=datetime.now(timezone.utc),
+            schedule_enabled=False,
+        )
+        mock_session.get.return_value = link
+        mock_session.exec.return_value.first.return_value = "OWNER"
+        mock_data_session.execute.return_value.scalars.return_value.all.return_value = [
+            "id",
+            "name",
+        ]
+        assert link.id is not None
+
+        response = get_joinable_columns(
+            integrity_link_id=link.id,
+            session=mock_session,
+            data_session=mock_data_session,
+            geo_ctx=self._geo_ctx("user0"),
+            group_ids=[],
+        )
+
+        assert [c.column_name for c in response] == ["id", "name"]
+
+    def test_403_when_user_has_no_access(
+        self, mock_session: MagicMock, mock_data_session: MagicMock
+    ) -> None:
+        link = IntegrityLink(
+            id=uuid4(),
+            integrity_title="Roads",
+            integrity_owner="user0",
+            integrity_organization="testorg",
+            source_import_type=ImportType.URL,
+            final_table_name="roads_final",
+            created_at=datetime.now(timezone.utc),
+            schedule_enabled=False,
+        )
+        mock_session.get.return_value = link
+        mock_session.exec.return_value.first.return_value = None
+        assert link.id is not None
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_joinable_columns(
+                integrity_link_id=link.id,
+                session=mock_session,
+                data_session=mock_data_session,
+                geo_ctx=self._geo_ctx("someone_else"),
+                group_ids=[],
+            )
+
+        assert exc_info.value.status_code == 403
+
+    def test_404_when_link_not_found(
+        self, mock_session: MagicMock, mock_data_session: MagicMock
+    ) -> None:
+        mock_session.get.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_joinable_columns(
+                integrity_link_id=uuid4(),
+                session=mock_session,
+                data_session=mock_data_session,
+                geo_ctx=self._geo_ctx("user0"),
+                group_ids=[],
+            )
+
+        assert exc_info.value.status_code == 404
+
+    def test_404_when_link_has_no_final_table(
+        self, mock_session: MagicMock, mock_data_session: MagicMock
+    ) -> None:
+        link = IntegrityLink(
+            id=uuid4(),
+            integrity_title="Not staged yet",
+            integrity_owner="user0",
+            integrity_organization="testorg",
+            source_import_type=ImportType.URL,
+            final_table_name=None,
+            created_at=datetime.now(timezone.utc),
+            schedule_enabled=False,
+        )
+        mock_session.get.return_value = link
+        mock_session.exec.return_value.first.return_value = "OWNER"
+        assert link.id is not None
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_joinable_columns(
+                integrity_link_id=link.id,
+                session=mock_session,
+                data_session=mock_data_session,
+                geo_ctx=self._geo_ctx("user0"),
+                group_ids=[],
+            )
+
+        assert exc_info.value.status_code == 404


### PR DESCRIPTION
Adds two read-only endpoints for the join-table picker: listing final tables available as join targets, and listing a table's columns. Both apply the same owner/METADATA-rule visibility rule used by the integrity-links list. Extracts that rule into a shared _visibility_condition helper reused by both endpoints.