### PR TITLE
fix: read plain tabular JSON and write null-geometry GeoDataFrames

### DIFF
--- a/apps/backend/src/api/routes/ingestion/staging.py
+++ b/apps/backend/src/api/routes/ingestion/staging.py
@@ -14,7 +14,7 @@ from data_manipulation import (
     detect_column_type_from_sqla,
     read_and_transform_data,
 )
-from data_manipulation.constants import DB_URI_PREFIX
+from data_manipulation.constants import DB_URI_PREFIX, DEFAULT_GEOMETRY_COLUMN
 from data_manipulation.database import schema_exists, table_exists
 from data_manipulation.ingestion import read_data_from_postgis
 from data_manipulation.logging import configure_logging
@@ -927,6 +927,12 @@ def get_staging_metadata(
         MetaData(schema=schema),
         autoload_with=data_engine,
     )
+    if source_file_type in (FileType.JSON, FileType.GEOJSON):
+        # The extension-based guess made at submission time can be wrong for these
+        # two: a .geojson source with no real geometry (e.g. an OGC Features
+        # service that always emits GeoJSON) reads as a plain table, and vice
+        # versa. Report what the staging table actually turned out to be.
+        source_file_type = FileType.GEOJSON if DEFAULT_GEOMETRY_COLUMN in table.c else FileType.JSON
     row_count = data_session.scalar(select(func.count()).select_from(table)) or 0
     original_projection = _detect_original_projection(
         staging_table_name,

--- a/apps/backend/tests/api/routes/conftest.py
+++ b/apps/backend/tests/api/routes/conftest.py
@@ -1,0 +1,23 @@
+from collections.abc import Generator
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def staging_metadata_deps() -> Generator[SimpleNamespace, None, None]:
+    """Patch every dependency get_staging_metadata needs besides the IntegrityLink
+    and staging table content, which each test configures itself via .load and
+    .table."""
+    with (
+        patch("src.api.routes.ingestion.staging.get_staging_schema", return_value="staging"),
+        patch("src.api.routes.ingestion.staging.select"),
+        patch("src.api.routes.ingestion.staging.Table") as mock_table,
+        patch("src.api.routes.ingestion.staging._resolve_columns") as mock_resolve_cols,
+        patch("src.api.routes.ingestion.staging._detect_original_projection") as mock_detect_proj,
+        patch("src.api.routes.ingestion.staging.load_authorized_integrity_link") as mock_load,
+    ):
+        mock_resolve_cols.return_value = ([], None)
+        mock_detect_proj.return_value = None
+        yield SimpleNamespace(load=mock_load, table=mock_table)

--- a/apps/backend/tests/api/routes/test_staging_api.py
+++ b/apps/backend/tests/api/routes/test_staging_api.py
@@ -1,6 +1,7 @@
 """Tests for API (OGC service) source type in staging endpoints."""
 
 from datetime import date, datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -16,7 +17,19 @@ from src.api.routes.ingestion.staging import (
     edit_staging,
     get_staging_metadata,
 )
-from src.models.data_import import ImportType
+from src.models.data_import import ImportType, StagingMetadataResponse
+
+
+def _call_get_staging_metadata() -> StagingMetadataResponse:
+    data_session = MagicMock()
+    data_session.scalar.return_value = 0
+    return get_staging_metadata(
+        data_session=data_session,
+        datafeeder_session=MagicMock(),
+        geo_ctx=MagicMock(),
+        integrity_link_id=str(uuid4()),
+        group_ids=[],
+    )
 
 
 class TestProcessImportSourceApi:
@@ -166,20 +179,8 @@ class TestGetStagingMetadataTitleFallbackApi:
 
         assert result.title == "ns:buildings"
 
-    @patch("src.api.routes.ingestion.staging.get_staging_schema", return_value="staging")
-    @patch("src.api.routes.ingestion.staging.select")
-    @patch("src.api.routes.ingestion.staging.Table")
-    @patch("src.api.routes.ingestion.staging._resolve_columns")
-    @patch("src.api.routes.ingestion.staging._detect_original_projection")
-    @patch("src.api.routes.ingestion.staging.load_authorized_integrity_link")
     def test_layer_name_returned_in_response_for_api_type(
-        self,
-        mock_load: MagicMock,
-        mock_detect_proj: MagicMock,
-        mock_resolve_cols: MagicMock,
-        mock_table: MagicMock,
-        mock_select: MagicMock,
-        mock_get_schema: MagicMock,
+        self, staging_metadata_deps: SimpleNamespace
     ) -> None:
         """layer_name field in response matches source_layer for API import type."""
         mock_link = MagicMock()
@@ -191,38 +192,15 @@ class TestGetStagingMetadataTitleFallbackApi:
         mock_link.source_layer = "ns:buildings"
         mock_link.integrity_transformation = None
         mock_link.final_table_name = None
-        mock_load.return_value = (mock_link, MagicMock())
-        mock_resolve_cols.return_value = ([], None)
-        mock_detect_proj.return_value = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
 
-        data_session = MagicMock()
-        data_session.scalar.return_value = 0
-
-        result = get_staging_metadata(
-            data_session=data_session,
-            datafeeder_session=MagicMock(),
-            geo_ctx=MagicMock(),
-            integrity_link_id=str(uuid4()),
-            group_ids=[],
-        )
+        result = _call_get_staging_metadata()
 
         assert result.title == "My WFS Layer"
         assert result.layer_name == "ns:buildings"
 
-    @patch("src.api.routes.ingestion.staging.get_staging_schema", return_value="staging")
-    @patch("src.api.routes.ingestion.staging.select")
-    @patch("src.api.routes.ingestion.staging.Table")
-    @patch("src.api.routes.ingestion.staging._resolve_columns")
-    @patch("src.api.routes.ingestion.staging._detect_original_projection")
-    @patch("src.api.routes.ingestion.staging.load_authorized_integrity_link")
     def test_layer_name_is_none_for_non_api_import_type(
-        self,
-        mock_load: MagicMock,
-        mock_detect_proj: MagicMock,
-        mock_resolve_cols: MagicMock,
-        mock_table: MagicMock,
-        mock_select: MagicMock,
-        mock_get_schema: MagicMock,
+        self, staging_metadata_deps: SimpleNamespace
     ) -> None:
         """layer_name is None in response for non-API import types."""
         mock_link = MagicMock()
@@ -234,20 +212,9 @@ class TestGetStagingMetadataTitleFallbackApi:
         mock_link.source_layer = None
         mock_link.integrity_transformation = None
         mock_link.final_table_name = None
-        mock_load.return_value = (mock_link, MagicMock())
-        mock_resolve_cols.return_value = ([], None)
-        mock_detect_proj.return_value = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
 
-        data_session = MagicMock()
-        data_session.scalar.return_value = 0
-
-        result = get_staging_metadata(
-            data_session=data_session,
-            datafeeder_session=MagicMock(),
-            geo_ctx=MagicMock(),
-            integrity_link_id=str(uuid4()),
-            group_ids=[],
-        )
+        result = _call_get_staging_metadata()
 
         assert result.layer_name is None
 

--- a/apps/backend/tests/api/routes/test_staging_database.py
+++ b/apps/backend/tests/api/routes/test_staging_database.py
@@ -1,6 +1,5 @@
 """Tests for database source type in staging endpoints."""
 
-from collections.abc import Generator
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -218,24 +217,6 @@ class TestDagSuccessCallbackDeleteGuard:
         mock_delete.assert_called_once_with("/tmp/somefile.csv")
 
 
-@pytest.fixture
-def staging_metadata_deps() -> Generator[SimpleNamespace, None, None]:
-    """Patch every dependency get_staging_metadata needs besides the IntegrityLink
-    and staging table content, which each test configures itself via .load and
-    .table."""
-    with (
-        patch("src.api.routes.ingestion.staging.get_staging_schema", return_value="staging"),
-        patch("src.api.routes.ingestion.staging.select"),
-        patch("src.api.routes.ingestion.staging.Table") as mock_table,
-        patch("src.api.routes.ingestion.staging._resolve_columns") as mock_resolve_cols,
-        patch("src.api.routes.ingestion.staging._detect_original_projection") as mock_detect_proj,
-        patch("src.api.routes.ingestion.staging.load_authorized_integrity_link") as mock_load,
-    ):
-        mock_resolve_cols.return_value = ([], None)
-        mock_detect_proj.return_value = None
-        yield SimpleNamespace(load=mock_load, table=mock_table)
-
-
 def _call_get_staging_metadata() -> StagingMetadataResponse:
     data_session = MagicMock()
     data_session.scalar.return_value = 0
@@ -251,20 +232,8 @@ def _call_get_staging_metadata() -> StagingMetadataResponse:
 class TestGetStagingMetadataTitleFallback:
     """Test title fallback logic in get_staging_metadata for database sources."""
 
-    @patch("src.api.routes.ingestion.staging.get_staging_schema", return_value="staging")
-    @patch("src.api.routes.ingestion.staging.select")
-    @patch("src.api.routes.ingestion.staging.Table")
-    @patch("src.api.routes.ingestion.staging._resolve_columns")
-    @patch("src.api.routes.ingestion.staging._detect_original_projection")
-    @patch("src.api.routes.ingestion.staging.load_authorized_integrity_link")
     def test_title_falls_back_to_table_name_from_source_url(
-        self,
-        mock_load: MagicMock,
-        mock_detect_proj: MagicMock,
-        mock_resolve_cols: MagicMock,
-        mock_table: MagicMock,
-        mock_select: MagicMock,
-        mock_get_schema: MagicMock,
+        self, staging_metadata_deps: SimpleNamespace
     ) -> None:
         """Title is the table name parsed from db://{schema}/{table} when no custom title is set."""
         mock_link = MagicMock()
@@ -275,37 +244,14 @@ class TestGetStagingMetadataTitleFallback:
         mock_link.source_url = "db://SOURCE_DB_1/geo/parcels"
         mock_link.integrity_transformation = None
         mock_link.final_table_name = None
-        mock_load.return_value = (mock_link, MagicMock())
-        mock_resolve_cols.return_value = ([], None)
-        mock_detect_proj.return_value = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
 
-        data_session = MagicMock()
-        data_session.scalar.return_value = 0
-
-        result = get_staging_metadata(
-            data_session=data_session,
-            datafeeder_session=MagicMock(),
-            geo_ctx=MagicMock(),
-            integrity_link_id=str(uuid4()),
-            group_ids=[],
-        )
+        result = _call_get_staging_metadata()
 
         assert result.title == "parcels"
 
-    @patch("src.api.routes.ingestion.staging.get_staging_schema", return_value="staging")
-    @patch("src.api.routes.ingestion.staging.select")
-    @patch("src.api.routes.ingestion.staging.Table")
-    @patch("src.api.routes.ingestion.staging._resolve_columns")
-    @patch("src.api.routes.ingestion.staging._detect_original_projection")
-    @patch("src.api.routes.ingestion.staging.load_authorized_integrity_link")
     def test_custom_title_overrides_table_name(
-        self,
-        mock_load: MagicMock,
-        mock_detect_proj: MagicMock,
-        mock_resolve_cols: MagicMock,
-        mock_table: MagicMock,
-        mock_select: MagicMock,
-        mock_get_schema: MagicMock,
+        self, staging_metadata_deps: SimpleNamespace
     ) -> None:
         """integrity_title takes precedence over table name derived from source_url."""
         mock_link = MagicMock()
@@ -316,37 +262,14 @@ class TestGetStagingMetadataTitleFallback:
         mock_link.source_url = "db://SOURCE_DB_1/geo/parcels"
         mock_link.integrity_transformation = None
         mock_link.final_table_name = None
-        mock_load.return_value = (mock_link, MagicMock())
-        mock_resolve_cols.return_value = ([], None)
-        mock_detect_proj.return_value = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
 
-        data_session = MagicMock()
-        data_session.scalar.return_value = 0
-
-        result = get_staging_metadata(
-            data_session=data_session,
-            datafeeder_session=MagicMock(),
-            geo_ctx=MagicMock(),
-            integrity_link_id=str(uuid4()),
-            group_ids=[],
-        )
+        result = _call_get_staging_metadata()
 
         assert result.title == "Parcelles cadastrales"
 
-    @patch("src.api.routes.ingestion.staging.get_staging_schema", return_value="staging")
-    @patch("src.api.routes.ingestion.staging.select")
-    @patch("src.api.routes.ingestion.staging.Table")
-    @patch("src.api.routes.ingestion.staging._resolve_columns")
-    @patch("src.api.routes.ingestion.staging._detect_original_projection")
-    @patch("src.api.routes.ingestion.staging.load_authorized_integrity_link")
     def test_title_strips_extension_from_source_file_name(
-        self,
-        mock_load: MagicMock,
-        mock_detect_proj: MagicMock,
-        mock_resolve_cols: MagicMock,
-        mock_table: MagicMock,
-        mock_select: MagicMock,
-        mock_get_schema: MagicMock,
+        self, staging_metadata_deps: SimpleNamespace
     ) -> None:
         """source_file_name extension is stripped when used as title fallback."""
         mock_link = MagicMock()
@@ -357,38 +280,13 @@ class TestGetStagingMetadataTitleFallback:
         mock_link.source_url = None
         mock_link.integrity_transformation = None
         mock_link.final_table_name = None
-        mock_load.return_value = (mock_link, MagicMock())
-        mock_resolve_cols.return_value = ([], None)
-        mock_detect_proj.return_value = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
 
-        data_session = MagicMock()
-        data_session.scalar.return_value = 0
-
-        result = get_staging_metadata(
-            data_session=data_session,
-            datafeeder_session=MagicMock(),
-            geo_ctx=MagicMock(),
-            integrity_link_id=str(uuid4()),
-            group_ids=[],
-        )
+        result = _call_get_staging_metadata()
 
         assert result.title == "data"
 
-    @patch("src.api.routes.ingestion.staging.get_staging_schema", return_value="staging")
-    @patch("src.api.routes.ingestion.staging.select")
-    @patch("src.api.routes.ingestion.staging.Table")
-    @patch("src.api.routes.ingestion.staging._resolve_columns")
-    @patch("src.api.routes.ingestion.staging._detect_original_projection")
-    @patch("src.api.routes.ingestion.staging.load_authorized_integrity_link")
-    def test_title_preserves_hidden_file_name(
-        self,
-        mock_load: MagicMock,
-        mock_detect_proj: MagicMock,
-        mock_resolve_cols: MagicMock,
-        mock_table: MagicMock,
-        mock_select: MagicMock,
-        mock_get_schema: MagicMock,
-    ) -> None:
+    def test_title_preserves_hidden_file_name(self, staging_metadata_deps: SimpleNamespace) -> None:
         """Hidden-file names (leading dot) are kept as-is without stripping the extension."""
         mock_link = MagicMock()
         mock_link.integrity_title = None
@@ -398,20 +296,9 @@ class TestGetStagingMetadataTitleFallback:
         mock_link.source_url = None
         mock_link.integrity_transformation = None
         mock_link.final_table_name = None
-        mock_load.return_value = (mock_link, MagicMock())
-        mock_resolve_cols.return_value = ([], None)
-        mock_detect_proj.return_value = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
 
-        data_session = MagicMock()
-        data_session.scalar.return_value = 0
-
-        result = get_staging_metadata(
-            data_session=data_session,
-            datafeeder_session=MagicMock(),
-            geo_ctx=MagicMock(),
-            integrity_link_id=str(uuid4()),
-            group_ids=[],
-        )
+        result = _call_get_staging_metadata()
 
         assert result.title == ".hidden"
 

--- a/apps/backend/tests/api/routes/test_staging_database.py
+++ b/apps/backend/tests/api/routes/test_staging_database.py
@@ -1,6 +1,8 @@
 """Tests for database source type in staging endpoints."""
 
+from collections.abc import Generator
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -15,7 +17,7 @@ from src.api.routes.ingestion.staging import (
     edit_staging,
     get_staging_metadata,
 )
-from src.models.data_import import ImportType
+from src.models.data_import import FileType, ImportType, StagingMetadataResponse
 
 
 class TestDbIdentifierValidation:
@@ -216,6 +218,36 @@ class TestDagSuccessCallbackDeleteGuard:
         mock_delete.assert_called_once_with("/tmp/somefile.csv")
 
 
+@pytest.fixture
+def staging_metadata_deps() -> Generator[SimpleNamespace, None, None]:
+    """Patch every dependency get_staging_metadata needs besides the IntegrityLink
+    and staging table content, which each test configures itself via .load and
+    .table."""
+    with (
+        patch("src.api.routes.ingestion.staging.get_staging_schema", return_value="staging"),
+        patch("src.api.routes.ingestion.staging.select"),
+        patch("src.api.routes.ingestion.staging.Table") as mock_table,
+        patch("src.api.routes.ingestion.staging._resolve_columns") as mock_resolve_cols,
+        patch("src.api.routes.ingestion.staging._detect_original_projection") as mock_detect_proj,
+        patch("src.api.routes.ingestion.staging.load_authorized_integrity_link") as mock_load,
+    ):
+        mock_resolve_cols.return_value = ([], None)
+        mock_detect_proj.return_value = None
+        yield SimpleNamespace(load=mock_load, table=mock_table)
+
+
+def _call_get_staging_metadata() -> StagingMetadataResponse:
+    data_session = MagicMock()
+    data_session.scalar.return_value = 0
+    return get_staging_metadata(
+        data_session=data_session,
+        datafeeder_session=MagicMock(),
+        geo_ctx=MagicMock(),
+        integrity_link_id=str(uuid4()),
+        group_ids=[],
+    )
+
+
 class TestGetStagingMetadataTitleFallback:
     """Test title fallback logic in get_staging_metadata for database sources."""
 
@@ -382,6 +414,89 @@ class TestGetStagingMetadataTitleFallback:
         )
 
         assert result.title == ".hidden"
+
+
+class TestGetStagingMetadataFileTypeOverride:
+    """The extension-based file_type guess is corrected against the actual staging
+    table for the two ambiguous cases (json/geojson) since a .geojson source can
+    turn out to have no real geometry (e.g. an OGC Features service that always
+    emits GeoJSON), and vice versa."""
+
+    def test_geojson_without_geom_column_reports_json(
+        self, staging_metadata_deps: SimpleNamespace
+    ) -> None:
+        mock_link = MagicMock()
+        mock_link.integrity_title = "Tarifs"
+        mock_link.source_file_name = "data.geojson"
+        mock_link.source_file_type = FileType.GEOJSON
+        mock_link.source_import_type = ImportType.URL
+        mock_link.source_url = None
+        mock_link.integrity_transformation = None
+        mock_link.final_table_name = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
+        staging_metadata_deps.table.return_value.c = {}  # no 'geom' column
+
+        result = _call_get_staging_metadata()
+
+        assert result.file_type == FileType.JSON
+
+    def test_geojson_with_geom_column_stays_geojson(
+        self, staging_metadata_deps: SimpleNamespace
+    ) -> None:
+        mock_link = MagicMock()
+        mock_link.integrity_title = "Parcelles"
+        mock_link.source_file_name = "data.geojson"
+        mock_link.source_file_type = FileType.GEOJSON
+        mock_link.source_import_type = ImportType.URL
+        mock_link.source_url = None
+        mock_link.integrity_transformation = None
+        mock_link.final_table_name = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
+        staging_metadata_deps.table.return_value.c = {"geom": MagicMock()}
+
+        result = _call_get_staging_metadata()
+
+        assert result.file_type == FileType.GEOJSON
+
+    def test_json_with_geom_column_reports_geojson(
+        self, staging_metadata_deps: SimpleNamespace
+    ) -> None:
+        """Symmetric case: a .json source whose staging table does have a geom
+        column (e.g. valid GeoJSON uploaded with a .json extension)."""
+        mock_link = MagicMock()
+        mock_link.integrity_title = "Points"
+        mock_link.source_file_name = "data.json"
+        mock_link.source_file_type = FileType.JSON
+        mock_link.source_import_type = ImportType.URL
+        mock_link.source_url = None
+        mock_link.integrity_transformation = None
+        mock_link.final_table_name = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
+        staging_metadata_deps.table.return_value.c = {"geom": MagicMock()}
+
+        result = _call_get_staging_metadata()
+
+        assert result.file_type == FileType.GEOJSON
+
+    def test_non_ambiguous_file_type_is_left_untouched(
+        self, staging_metadata_deps: SimpleNamespace
+    ) -> None:
+        """CSV/GPKG/etc. never go through the json/geojson override, regardless of
+        whether the staging table happens to have a geom column."""
+        mock_link = MagicMock()
+        mock_link.integrity_title = "Communes"
+        mock_link.source_file_name = "data.csv"
+        mock_link.source_file_type = FileType.CSV
+        mock_link.source_import_type = ImportType.URL
+        mock_link.source_url = None
+        mock_link.integrity_transformation = None
+        mock_link.final_table_name = None
+        staging_metadata_deps.load.return_value = (mock_link, MagicMock())
+        staging_metadata_deps.table.return_value.c = {}
+
+        result = _call_get_staging_metadata()
+
+        assert result.file_type == FileType.CSV
 
 
 class TestEditStagingDatabase:

--- a/libs/data_manipulation/src/data_manipulation/ingestion.py
+++ b/libs/data_manipulation/src/data_manipulation/ingestion.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -97,6 +98,19 @@ def _detect_file_encoding(file_path: str) -> str:
     return encoding or "utf-8"
 
 
+def _read_tabular_json(file_path: str) -> pd.DataFrame:
+    """Read a plain (non-GeoJSON) JSON file as a flat table: a list becomes rows,
+    a single object becomes one row."""
+    with open(file_path, "rb") as f:
+        data = json.load(f)
+
+    if isinstance(data, list):
+        return pd.DataFrame(data)
+    if isinstance(data, dict):
+        return pd.DataFrame([data])
+    raise ValueError(f"Unsupported JSON structure in {file_path}: expected an array or object")
+
+
 def _read_file_encoded(file_path: str, i: int = 0) -> gpd.GeoDataFrame | pd.DataFrame:
     """Read a chunk of a geospatial file, handling encoding detection.
 
@@ -122,6 +136,13 @@ def _read_file_encoded(file_path: str, i: int = 0) -> gpd.GeoDataFrame | pd.Data
             return gpd.read_parquet(ds.fragments[i].path)  # type: ignore[arg-type]
         except ValueError:
             return pd.read_parquet(ds.fragments[i].path)
+
+    # Not row-sliceable like a geospatial driver: read fully on the first chunk,
+    # same pattern as the Parquet branch above.
+    if Path(file_path).suffix.lower() == ".json":
+        if i > 0:
+            return pd.DataFrame()
+        return _read_tabular_json(file_path)
 
     try:
         # Try reading with UTF-8 first (common default)
@@ -728,6 +749,17 @@ def write_data_to_postgis(
 
             # Write data to PostGIS as a regular table
             data.to_sql(table_name, engine, if_exists=if_exists, schema=schema, index=False)
+        elif data.active_geometry_name is not None and bool(
+            data[data.active_geometry_name].isna().all()
+        ):
+            # to_postgis() can't infer a geometry type with zero non-null geometries
+            # (e.g. a GeoJSON FeatureCollection with "geometry": null everywhere).
+            logger.info(
+                f"Active geometry column '{data.active_geometry_name}' has no non-null "
+                "geometries; writing as a plain table."
+            )
+            plain_data = pd.DataFrame(data.drop(columns=[data.active_geometry_name]))
+            plain_data.to_sql(table_name, engine, if_exists=if_exists, schema=schema, index=False)
         else:  # GeoDataFrame
             # Ensure the geometry column is named 'geom' for PostGIS convention
             if data.active_geometry_name is None:

--- a/libs/data_manipulation/tests/test_ingestion.py
+++ b/libs/data_manipulation/tests/test_ingestion.py
@@ -1,9 +1,11 @@
 """Tests for data ingestion utilities in data_manipulation library."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 from urllib.error import URLError
 
 import geopandas as gpd
+import pandas as pd
 import pytest
 import requests
 from geopandas import GeoDataFrame
@@ -63,6 +65,53 @@ class TestReadFileEncodedParquet:
 
         mock_read_parquet.assert_called_once_with("test.parquet")
         assert result is mock_gdf
+
+
+class TestReadFileEncodedTabularJson:
+    """.json dispatch in _read_file_encoded (plain tabular JSON, never GeoJSON)."""
+
+    def test_array_of_records(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "data.json"
+        file_path.write_text('[{"id": 1, "name": "foo"}, {"id": 2, "name": "bar"}]')
+
+        result = _read_file_encoded(str(file_path))
+
+        assert result.to_dict("records") == [{"id": 1, "name": "foo"}, {"id": 2, "name": "bar"}]
+
+    def test_single_object_becomes_one_row(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "data.json"
+        file_path.write_text('{"id": 1, "name": "foo"}')
+
+        result = _read_file_encoded(str(file_path))
+
+        assert result.to_dict("records") == [{"id": 1, "name": "foo"}]
+
+    def test_records_with_sparse_keys_union_columns(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "data.json"
+        file_path.write_text('[{"id": 1, "name": "foo"}, {"id": 2, "price": 9.99}]')
+
+        result = _read_file_encoded(str(file_path))
+
+        assert sorted(result.columns) == ["id", "name", "price"]
+        assert result.loc[0, "name"] == "foo"
+        assert pd.isna(result.loc[1, "name"])
+        assert result.loc[1, "price"] == 9.99
+        assert pd.isna(result.loc[0, "price"])
+
+    def test_unsupported_top_level_scalar_raises(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "data.json"
+        file_path.write_text("42")
+
+        with pytest.raises(ValueError, match="Unsupported JSON structure"):
+            _read_file_encoded(str(file_path))
+
+    def test_second_chunk_is_empty(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "data.json"
+        file_path.write_text('[{"id": 1}, {"id": 2}]')
+
+        result = _read_file_encoded(str(file_path), i=1)
+
+        assert result.empty
 
 
 class TestIngestDataFromFileIntoPostgis:
@@ -739,6 +788,38 @@ class TestWriteDataToPostgis:
             # Should have been renamed to 'geom'
             assert gdf.geometry.name == "geom"
             mock_to_postgis.assert_called_once()
+
+    @patch("pandas.DataFrame.to_sql", autospec=True)
+    @patch("data_manipulation.ingestion._get_table_row_count")
+    def test_write_geodataframe_with_null_geometry_writes_as_plain_table(
+        self,
+        mock_get_row_count: Mock,
+        mock_to_sql: Mock,
+        mock_engine: Mock,
+    ) -> None:
+        """A geometry column that's entirely null (e.g. a GeoJSON FeatureCollection with
+        "geometry": null on every feature) is written as a plain table, not to_postgis,
+        which would otherwise crash trying to infer a PostGIS geometry type."""
+        gdf = GeoDataFrame(
+            {"col1": [1, 2]},
+            geometry=gpd.GeoSeries([None, None], name="geometry"),  # type: ignore[list-item]
+        )
+        mock_get_row_count.return_value = 2
+
+        with patch.object(gdf, "to_postgis") as mock_to_postgis:
+            write_data_to_postgis(gdf, "test_table", mock_engine, "public")
+
+        mock_to_postgis.assert_not_called()
+        mock_to_sql.assert_called_once()
+        # autospec=True binds self, so the instance it was called on is args[0].
+        written_frame, table_arg = mock_to_sql.call_args.args[0], mock_to_sql.call_args.args[1]
+        kwargs = mock_to_sql.call_args.kwargs
+        assert table_arg == "test_table"
+        assert kwargs["if_exists"] == "replace"
+        assert kwargs["schema"] == "public"
+        assert kwargs["index"] is False
+        # The written frame must not carry the (all-null, useless) geometry column.
+        assert "geometry" not in written_frame.columns
 
     @patch("data_manipulation.ingestion._get_table_row_count")
     def test_write_geodataframe_without_geometry(


### PR DESCRIPTION
Detects and correctly handles plain tabular JSON and non-spatial GeoJSON (e.g. `"geometry": null` on every feature) during ingestion:

- `_read_file_encoded` reads `.json` files as a table directly via pandas, without touching `.geojson` handling.
- `write_data_to_postgis` writes a GeoDataFrame with an entirely-null geometry column as a plain table instead of crashing (`to_postgis()` previously raised "No valid geometries in the data.").
- `get_staging_metadata` now reports the actual `file_type` (json vs geojson) based on the resulting staging table, not just the source extension.

Also dedupes repeated test setup into a shared `conftest.py` fixture.